### PR TITLE
SWITCHYARD-552 add catalog entries for missing bpel and rules schema;  modified pom versioning for eclipse plugins

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.core/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.core/pom.xml
@@ -12,10 +12,6 @@
   <name>SwitchYard: Eclipse Tools Core Plugin</name>
   <description>Provides core SwitchYard functionality for use by Eclipse plugins.</description>
 
-  <properties>
-    <switchyard.version>${project.parent.version}</switchyard.version>
-  </properties>
-
   <build>
     <plugins>
       <plugin>
@@ -35,12 +31,12 @@
                 <artifactItem>
                   <groupId>org.switchyard</groupId>
                   <artifactId>switchyard-common</artifactId>
-                  <version>${switchyard.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.switchyard</groupId>
                   <artifactId>switchyard-config</artifactId>
-                  <version>${switchyard.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/eclipse/plugins/org.switchyard.tools.xsd/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.xsd/pom.xml
@@ -30,7 +30,7 @@
                 <artifactItem>
                   <groupId>org.switchyard</groupId>
                   <artifactId>switchyard-config</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>
@@ -38,7 +38,7 @@
                 <artifactItem>
                   <groupId>org.switchyard</groupId>
                   <artifactId>switchyard-transform</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>
@@ -46,7 +46,15 @@
                 <artifactItem>
                   <groupId>org.switchyard.components</groupId>
                   <artifactId>switchyard-component-bean</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
+                  <classifier>sources</classifier>
+                  <type>jar</type>
+                  <includes>**/*.xsd</includes>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.switchyard.components</groupId>
+                  <artifactId>switchyard-component-bpel</artifactId>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>
@@ -54,7 +62,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.components</groupId>
                   <artifactId>switchyard-component-bpm</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>
@@ -62,7 +70,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.components</groupId>
                   <artifactId>switchyard-component-camel</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>
@@ -70,7 +78,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.components</groupId>
                   <artifactId>switchyard-component-clojure</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>
@@ -78,7 +86,15 @@
                 <artifactItem>
                   <groupId>org.switchyard.components</groupId>
                   <artifactId>switchyard-component-hornetq</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
+                  <classifier>sources</classifier>
+                  <type>jar</type>
+                  <includes>**/*.xsd</includes>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.switchyard.components</groupId>
+                  <artifactId>switchyard-component-common-rules</artifactId>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>
@@ -86,7 +102,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.components</groupId>
                   <artifactId>switchyard-component-rules</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>
@@ -94,7 +110,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.components</groupId>
                   <artifactId>switchyard-component-soap</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <includes>**/*.xsd</includes>

--- a/eclipse/plugins/org.switchyard.tools.xsd/switchyard_catalog.xml
+++ b/eclipse/plugins/org.switchyard.tools.xsd/switchyard_catalog.xml
@@ -7,10 +7,12 @@
 
   <!-- Specialized SwitchYard component schema. -->
   <public publicId="urn:switchyard-component-bean:config:1.0" uri="org/switchyard/component/bean/config/model/v1/bean-v1.xsd" />
+  <public publicId="http://docs.oasis-open.org/ns/opencsa/sca/200903" uri="org/switchyard/component/bpel/config/model/v1/bpel-v1.xsd" />
   <public publicId="urn:switchyard-component-bpm:config:1.0" uri="org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd" />
   <public publicId="urn:switchyard-component-camel:config:1.0" uri="org/switchyard/component/camel/config/model/v1/camel-v1.xsd" />
   <public publicId="urn:switchyard-component-clojure:config:1.0" uri="org/switchyard/component/clojure/config/model/v1/clojure-v1.xsd" />
   <public publicId="urn:switchyard-component-hornetq:config:1.0" uri="org/switchyard/component/hornetq/config/model/v1/hornetq-v1.xsd" />
+  <public publicId="urn:switchyard-component-common-rules:config:1.0" uri="org/switchyard/component/common/rules/config/model/v1/common-rules-v1.xsd" />
   <public publicId="urn:switchyard-component-rules:config:1.0" uri="org/switchyard/component/rules/config/model/v1/rules-v1.xsd" />
   <public publicId="urn:switchyard-component-soap:config:1.0" uri="org/switchyard/component/soap/config/model/v1/soap-v1.xsd" />
 

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -8,12 +8,21 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>switchyard-tools-eclipse</artifactId>
+  <!--
+    Eclipse plugin build versioning (M.m.r.build) is handled through Tycho, so
+    versions like 0.3.0.CR1 and 0.3.0.Final would be handled by Tycho.  The
+    parent project's version, not being Eclipse specific, should continue to
+    evolve along with the rest of the SwitchYard projects.
+  -->
+  <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SwitchYard: Eclipse Tools Parent</name>
   <description>Parent project for Eclipse based SwitchYard tooling.</description>
 
   <properties>
     <tycho-version>0.12.0</tycho-version>
+    <!-- Just in case the Eclipse project version does not match the parent. -->
+    <version.switchyard.runtime>${project.parent.version}</version.switchyard.runtime>
   </properties>
 
   <modules>

--- a/eclipse/tests/org.switchyard.tools.m2e.tests/pom.xml
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/pom.xml
@@ -47,7 +47,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts</groupId>
                   <artifactId>switchyard-quickstart-bean-service</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <outputDirectory>test-data/projects/bean-service/src/main/java</outputDirectory>
@@ -55,7 +55,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts.demos</groupId>
                   <artifactId>switchyard-quickstart-demo-helpdesk</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <outputDirectory>test-data/projects/helpdesk/src/main/java</outputDirectory>
@@ -75,7 +75,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts</groupId>
                   <artifactId>switchyard-quickstart-bean-service</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <outputDirectory>test-data/projects/bean-service/src/main/resources</outputDirectory>
@@ -83,7 +83,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts.demos</groupId>
                   <artifactId>switchyard-quickstart-demo-helpdesk</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <classifier>sources</classifier>
                   <type>jar</type>
                   <outputDirectory>test-data/projects/helpdesk/src/main/resources</outputDirectory>
@@ -102,7 +102,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts</groupId>
                   <artifactId>switchyard-quickstart-bean-service</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <type>pom</type>
                   <outputDirectory>test-data/projects/bean-service</outputDirectory>
                   <destFileName>pom.xml</destFileName>
@@ -110,7 +110,7 @@
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts.demos</groupId>
                   <artifactId>switchyard-quickstart-demo-helpdesk</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <type>pom</type>
                   <outputDirectory>test-data/projects/helpdesk</outputDirectory>
                   <destFileName>pom.xml</destFileName>
@@ -130,14 +130,14 @@
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts</groupId>
                   <artifactId>switchyard-quickstart-bean-service</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <type>jar</type>
                   <outputDirectory>test-data/validation/bean-service</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts.demos</groupId>
                   <artifactId>switchyard-quickstart-demo-helpdesk</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.switchyard.runtime}</version>
                   <type>jar</type>
                   <outputDirectory>test-data/validation/helpdesk</outputDirectory>
                 </artifactItem>


### PR DESCRIPTION
added missing schema to XSD catalog.

separated pom version from Eclipse plugins and parent plugin.  see comments in tools/eclipse/pom.xml
