### PR TITLE
SWITCHYARD-455 add facet for SwitchYard projects

### DIFF
--- a/eclipse/features/org.switchyard.tools.feature/feature.xml
+++ b/eclipse/features/org.switchyard.tools.feature/feature.xml
@@ -167,9 +167,12 @@ NO WARRANTY
    <requires>
       <import feature="org.eclipse.platform" version="3.6.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.jdt" version="3.6.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.wst.xml_core.feature" version="1.0.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.wst.common.fproj" version="3.2.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.jst.web_core.feature" version="3.2.0" match="greaterOrEqual"/>
       <import feature="org.eclipse.m2e.feature" version="1.0.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.wst.common_core.feature" version="3.2.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.wst.common.fproj" version="3.2.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.wst.server_core.feature" version="3.2.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.wst.xml_core.feature" version="1.0.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/eclipse/plugins/org.switchyard.tools.m2e/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.m2e/META-INF/MANIFEST.MF
@@ -7,5 +7,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.core.resources;bundle-version="3.4.2",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.1.0)",
- org.eclipse.m2e.core;bundle-version="[1.0.0,1.1.0)"
+ org.eclipse.m2e.core;bundle-version="[1.0.0,1.1.0)",
+ org.eclipse.wst.common.project.facet.core;bundle-version="1.4.0"
 Bundle-Vendor: www.jboss.org

--- a/eclipse/plugins/org.switchyard.tools.m2e/src/org/switchyard/tools/m2e/SwitchYardProjectConfigurator.java
+++ b/eclipse/plugins/org.switchyard.tools.m2e/src/org/switchyard/tools/m2e/SwitchYardProjectConfigurator.java
@@ -26,11 +26,17 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
 import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
 import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
+import org.eclipse.wst.common.project.facet.core.IFacetedProject;
+import org.eclipse.wst.common.project.facet.core.IFacetedProjectWorkingCopy;
+import org.eclipse.wst.common.project.facet.core.IPreset;
+import org.eclipse.wst.common.project.facet.core.IProjectFacet;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 
 /**
  * SwitchYardProjectConfigurator
  * 
- * M2E project configurator for SwitchYard mojo.
+ * M2E project configurator for SwitchYard. Installs required project facets.
  * 
  * @see AbstractProjectConfigurator
  * 
@@ -38,9 +44,34 @@ import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
  */
 public class SwitchYardProjectConfigurator extends AbstractProjectConfigurator {
 
+    private static final IProjectFacet UTILITY_MODULE_FACET;
+
     @Override
     public void configure(ProjectConfigurationRequest request, IProgressMonitor monitor) throws CoreException {
-        // nothing to do as we don't contribute any source or resource elements.
+        IFacetedProject facetedProject = ProjectFacetsManager.create(request.getProject(), true, monitor);
+        IFacetedProjectWorkingCopy ifpwc = facetedProject.createWorkingCopy();
+        IPreset switchYardBasicPreset = getSwitchYardBasicPreset(ifpwc);
+        if (switchYardBasicPreset == null) {
+            return;
+        }
+        // add SwitchYard facets
+        boolean modified = false;
+        for (IProjectFacetVersion facet : switchYardBasicPreset.getProjectFacets()) {
+            if (!ifpwc.hasProjectFacet(facet.getProjectFacet())) {
+                ifpwc.addProjectFacet(facet);
+                modified = true;
+            }
+        }
+        // make sure a JEE facet is installed
+        if (UTILITY_MODULE_FACET != null && "jar".equals(request.getMavenProject().getPackaging())
+                && !ifpwc.hasProjectFacet(UTILITY_MODULE_FACET)) {
+            // add utility module facet
+            ifpwc.addProjectFacet(UTILITY_MODULE_FACET.getDefaultVersion());
+            modified = true;
+        }
+        if (modified) {
+            ifpwc.commitChanges(monitor);
+        }
     }
 
     @Override
@@ -49,5 +80,21 @@ public class SwitchYardProjectConfigurator extends AbstractProjectConfigurator {
         return new SwitchYardBuildParticipant(execution);
     }
 
+    private IPreset getSwitchYardBasicPreset(IFacetedProjectWorkingCopy ifpwc) {
+        for (IPreset preset : ifpwc.getAvailablePresets()) {
+            if ("preset.switchyard.basic".equals(preset.getId())) {
+                return preset;
+            }
+        }
+        return null;
+    }
+
+    static {
+        if (ProjectFacetsManager.isProjectFacetDefined("jst.utility")) {
+            UTILITY_MODULE_FACET = ProjectFacetsManager.getProjectFacet("jst.utility");
+        } else {
+            UTILITY_MODULE_FACET = null;
+        }
+    }
 
 }

--- a/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
@@ -13,9 +13,14 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.core;bundle-version="3.3.0",
  org.eclipse.jdt.ui;bundle-version="3.3.0",
  org.eclipse.wst.common.project.facet.core;bundle-version="1.4.0",
+ org.eclipse.wst.common.project.facet.ui;bundle-version="1.4.0",
+ org.eclipse.wst.common.frameworks;bundle-version="1.2.0",
  org.eclipse.m2e.maven.runtime;bundle-version="1.0.0",
- org.eclipse.m2e.core,
- org.switchyard.tools.core;bundle-version="0.4.0"
+ org.eclipse.m2e.core;bundle-version="1.0.0",
+ org.switchyard.tools.core;bundle-version="0.4.0",
+ org.eclipse.wst.server.core;bundle-version="1.1.0",
+ org.eclipse.jst.jee;bundle-version="1.0.0",
+ org.eclipse.jst.j2ee;bundle-version="1.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: org.switchyard.tools.ui,

--- a/eclipse/plugins/org.switchyard.tools.ui/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui/plugin.xml
@@ -46,23 +46,168 @@
    </extension>
    <extension
          point="org.eclipse.wst.common.project.facet.core.presets">
+      <dynamic-preset
+            id="preset.switchyard.basic">
+         <factory
+               class="org.switchyard.tools.ui.facets.SwitchYardBasicPresetFactory">
+         </factory>
+      </dynamic-preset>
       <static-preset
-            id="org.switchyard.tools.ui.facet.switchYardJarPreset">
+            extends="preset.switchyard.basic"
+            id="preset.switchyard.jar">
          <description>
-            Basic project facet preset for SwitchYard applications packaged as JARs.
+            Project facet set for SwitchYard JAR applications.
          </description>
          <label>
-            SwitchYard Application - JAR
+            SwitchYard Java Application
          </label>
-         <facet
-               id="java"
-               version="1.6">
-         </facet>
          <facet
                id="jst.utility"
                version="1.0">
          </facet>
       </static-preset>
    </extension>
+
+   <extension
+         point="org.eclipse.wst.common.project.facet.core.facets">
+      <project-facet
+            id="switchyard.core">
+         <default-version
+               version="1.0">
+         </default-version>
+    	 <property name="hide.version" value="true"/>
+         <description>
+            SwitchYard functionality.
+         </description>
+         <label>
+            SwitchYard
+         </label>
+      </project-facet>
+      <project-facet-version
+            facet="switchyard.core"
+            version="1.0">
+         <constraint>
+         	<and>
+	            <requires
+	                  facet="jst.java"
+	                  version="[6.0">
+	            </requires>
+	            <!-- currently only support maven builds -->
+	            <requires
+                   facet="jboss.m2"
+                   soft="true"
+                   version="*">
+	            </requires>
+            </and>
+         </constraint>
+      </project-facet-version>
+      <action
+            facet="switchyard.core"
+            id="switchyard.core.install"
+            type="install"
+            version="1.0">
+         <delegate
+               class="org.switchyard.tools.ui.facets.SwitchYardFacetInstallActionDelegate">
+         </delegate>
+         <config-factory
+               class="org.switchyard.tools.ui.facets.SwitchYardFacetInstallConfigFactory">
+         </config-factory>
+      </action>
+      <action
+            facet="switchyard.core"
+            id="switchyard.core.uninstall"
+            type="uninstall"
+            version="1.0">
+         <delegate
+               class="org.switchyard.tools.ui.facets.SwitchYardFacetUnInstallActionDelegate">
+         </delegate>
+      </action>
+   </extension>
+
+  <extension point="org.eclipse.wst.common.project.facet.ui.images">
+    <image 
+      facet="switchyard.core" 
+      path="icons/switchyard_icon_16px.png"/>
+  </extension>
+
+  <extension point="org.eclipse.wst.common.project.facet.ui.wizardPages">
+    <wizard-pages action="switchyard.core.install">
+      <page class="org.switchyard.tools.ui.facets.SwitchYardFacetInstallWizardPage"/>
+    </wizard-pages>
+  </extension>
+  <extension
+        point="org.eclipse.wst.common.project.facet.core.runtimes">
+     <supported>
+        <facet
+              id="switchyard.core"
+              version="1.0">
+        </facet>
+        <runtime-component
+              any="true">
+        </runtime-component>
+     </supported>
+  </extension>
+  <!--
+  <extension
+        point="org.eclipse.wst.common.project.facet.core.defaultFacets">
+     <default-facets>
+        <facet
+              id="switchyard.core"
+              version="1.0">
+        </facet>
+        <runtime-component
+              id="org.jboss.ide.eclipse.as.runtime.component"
+              version="[7.0">
+        </runtime-component>
+     </default-facets>
+  </extension>
+  -->
+
+  <extension
+        point="org.eclipse.wst.server.core.moduleTypes">
+     <moduleType
+           id="switchyard.core"
+           name="SwitchYard Application">
+     </moduleType>
+  </extension>
+  <extension
+        point="org.eclipse.wst.common.modulecore.componentimpl">
+     <componentimpl
+           typeID="switchyard.core"
+           class="org.eclipse.jst.j2ee.componentcore.J2EEModuleVirtualComponent">
+     </componentimpl>
+  </extension>
+  <extension
+        point="org.eclipse.wst.server.core.moduleFactories">
+     <moduleFactory
+           class="org.eclipse.jst.jee.internal.deployables.JEEDeployableFactory"
+           id="switchyard.deployable"
+           order="10"
+           projects="true">
+        <moduleType
+              types="switchyard.core"
+              versions="1.0">
+        </moduleType>
+     </moduleFactory>
+  </extension>
+  <extension
+        point="org.eclipse.wst.server.core.moduleArtifactAdapters">
+     <moduleArtifactAdapter
+           class="org.switchyard.tools.ui.modules.SwitchYardModuleArtifactAdapterDelegate"
+           id="org.switchyard.tools.ui.moduleArtifactAdapter1">
+          <enablement>
+             <with
+                   variable="selection">
+                <adapt
+                      type="org.eclipse.core.resources.IProject">
+                   <test
+                         forcePluginActivation="true"
+                         property="org.eclipse.wst.common.project.facet.core.projectFacet"
+                         value="switchyard.core">
+                   </test>
+                </adapt>
+             </with></enablement>
+     </moduleArtifactAdapter>
+  </extension>
 
 </plugin>

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/ISwitchYardFacetConstants.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/ISwitchYardFacetConstants.java
@@ -1,0 +1,55 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.facets;
+
+/**
+ * ISwitchYardFacetConstants
+ * 
+ * Constants used within the SwitchYard project facet extension.
+ * 
+ * @author Rob Cernich
+ */
+public interface ISwitchYardFacetConstants {
+
+    /**
+     * Property ID used to indicate whether or not the runtime supplies the
+     * SwitchYard dependencies.
+     */
+    public static final String RUNTIME_PROVIDED = "SwitchYard.RUNTIME_PROVIDED";
+    /** Property ID used to indicate the desired SwitchYard runtime version. */
+    public static final String RUNTIME_VERSION = "SwitchYard.RUNTIME_VERSION";
+
+    /** The ID of the SwitchYard facet. */
+    public static final String SWITCHYARD_FACET_ID = "switchyard.core";
+
+    /** The ID of the basic SwitchYard facet set. */
+    public static final String SWITCHYARD_BASIC_PRESET_ID = "preset.switchyard.basic";
+    /** The ID of the JAR SwitchYard facet set. */
+    public static final String SWITCHYARD_JAR_PRESET_ID = "preset.switchyard.jar";
+
+    /** The ID of the framework default facet set. */
+    public static final String DEFAULT_PRESET_ID = "default.configuration";
+    /** The ID of the Java facet. */
+    public static final String JAVA_FACET_ID = "java";
+    /** Our preferred version of Java. */
+    public static final String JAVA_FACET_VERSION = "1.6";
+    /** The ID of the JBoss Maven Integration facet. */
+    public static final String JBOSS_M2_FACET_ID = "jboss.m2";
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardBasicPresetFactory.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardBasicPresetFactory.java
@@ -1,0 +1,84 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.facets;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.wst.common.project.facet.core.IDynamicPreset;
+import org.eclipse.wst.common.project.facet.core.IPreset;
+import org.eclipse.wst.common.project.facet.core.IPreset.Type;
+import org.eclipse.wst.common.project.facet.core.IPresetFactory;
+import org.eclipse.wst.common.project.facet.core.IProjectFacet;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+import org.eclipse.wst.common.project.facet.core.PresetDefinition;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+
+/**
+ * SwitchYardBasicPresetFactory
+ * 
+ * Provides the basic facets required for a simple SwitchYard project:
+ * switchyard.core, java, jboss.m2 (optional).
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardBasicPresetFactory implements IPresetFactory, ISwitchYardFacetConstants {
+
+    /**
+     * Create a new SwitchYardBasicPresetFactory.
+     */
+    public SwitchYardBasicPresetFactory() {
+    }
+
+    @Override
+    public PresetDefinition createPreset(String presetId, Map<String, Object> context) throws CoreException {
+        Set<IProjectFacetVersion> facets = new HashSet<IProjectFacetVersion>();
+
+        // default facets
+        IPreset defaultPreset = ProjectFacetsManager.getPreset(DEFAULT_PRESET_ID);
+        if (defaultPreset != null) {
+            if (defaultPreset.getType() == Type.DYNAMIC) {
+                ((IDynamicPreset) defaultPreset).resolve(context);
+            }
+            facets.addAll(defaultPreset.getProjectFacets());
+        }
+
+        // SwitchYard facet
+        facets.add(ProjectFacetsManager.getProjectFacet(SWITCHYARD_FACET_ID).getDefaultVersion());
+
+        // Java facet; prefer 1.6 or later
+        IProjectFacet javaFacet = ProjectFacetsManager.getProjectFacet(JAVA_FACET_ID);
+        IProjectFacetVersion javaFacetVersion = javaFacet.getVersion(JAVA_FACET_VERSION);
+        if (javaFacetVersion == null) {
+            javaFacetVersion = javaFacet.getLatestVersion();
+        }
+        facets.add(javaFacetVersion);
+
+        // JBoss Maven Integration facet (if available)
+        if (ProjectFacetsManager.isProjectFacetDefined(JBOSS_M2_FACET_ID)) {
+            facets.add(ProjectFacetsManager.getProjectFacet(JBOSS_M2_FACET_ID).getDefaultVersion());
+        }
+
+        return new PresetDefinition("Basic SwitchYard Application",
+                "Basic project facet set for SwitchYard applications.", facets);
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallActionDelegate.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallActionDelegate.java
@@ -1,0 +1,64 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.facets;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.wst.common.frameworks.datamodel.IDataModel;
+import org.eclipse.wst.common.project.facet.core.IDelegate;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+import org.sonatype.aether.version.Version;
+import org.switchyard.tools.ui.M2EUtils;
+import org.switchyard.tools.ui.operations.AbstractSwitchYardProjectOperation;
+
+/**
+ * SwitchYardFacetInstallActionDelegate
+ * 
+ * Add SwitchYard specific details to project.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardFacetInstallActionDelegate implements IDelegate {
+
+    @Override
+    public void execute(final IProject project, IProjectFacetVersion fv, Object config, IProgressMonitor monitor)
+            throws CoreException {
+        Object versionObject = config instanceof IDataModel ? ((IDataModel) config)
+                .getProperty(ISwitchYardFacetConstants.RUNTIME_VERSION) : null;
+        String versionString = versionObject instanceof Version ? ((Version) versionObject).toString() : null;
+        // make sure the sy stuff is in the pom
+        new AbstractSwitchYardProjectOperation(versionString, M2EUtils.DEFAULT_DEPENDENCIES,
+                Arrays.asList(M2EUtils.DEFAULT_SCANNERS), false, "Installing SwitchYard Facet", null) {
+            @Override
+            protected void execute(IProgressMonitor monitor) throws CoreException {
+                // nothing extra
+            }
+
+            @Override
+            protected IProject getProject() {
+                return project;
+            }
+
+        }.run(monitor);
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallConfigFactory.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallConfigFactory.java
@@ -1,0 +1,99 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.facets;
+
+import java.util.Set;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.wst.common.componentcore.datamodel.FacetInstallDataModelProvider;
+import org.eclipse.wst.common.project.facet.core.IFacetedProjectWorkingCopy;
+import org.sonatype.aether.util.version.GenericVersionScheme;
+import org.sonatype.aether.version.Version;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.M2EUtils;
+
+/**
+ * SwitchYardFacetInstallConfigFactory
+ * 
+ * Creates configuration object used when installing the SwitchYard facet.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardFacetInstallConfigFactory extends FacetInstallDataModelProvider implements
+        ISwitchYardFacetConstants {
+
+    @SuppressWarnings({"rawtypes", "unchecked" })
+    @Override
+    public Set getPropertyNames() {
+        Set names = super.getPropertyNames();
+        names.add(RUNTIME_PROVIDED);
+        names.add(RUNTIME_VERSION);
+        return names;
+    }
+
+    @Override
+    public Object getDefaultProperty(String propertyName) {
+        if (FACET_ID.equals(propertyName)) {
+            return SWITCHYARD_FACET_ID;
+        } else if (RUNTIME_PROVIDED.equals(propertyName)) {
+            return true;
+        } else if (RUNTIME_VERSION.equals(propertyName)) {
+            IFacetedProjectWorkingCopy ifpwc = (IFacetedProjectWorkingCopy) getProperty(FACETED_PROJECT_WORKING_COPY);
+            if (ifpwc == null || !ifpwc.getProject().exists()) {
+                return null;
+            }
+            String versionString = M2EUtils.getSwitchYardVersion(ifpwc.getProject());
+            if (versionString == null || versionString.length() == 0) {
+                return null;
+            }
+            try {
+                return new GenericVersionScheme().parseVersion(versionString);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+        return super.getDefaultProperty(propertyName);
+    }
+
+    @Override
+    public boolean propertySet(String propertyName, Object propertyValue) {
+        if (RUNTIME_PROVIDED.equals(propertyName)) {
+            return true;
+        } else if (RUNTIME_VERSION.equals(propertyName)) {
+            return true;
+        }
+        return super.propertySet(propertyName, propertyValue);
+    }
+
+    @Override
+    public IStatus validate(String name) {
+        if (RUNTIME_PROVIDED.equals(name)) {
+            return Status.OK_STATUS;
+        } else if (RUNTIME_VERSION.equals(name)) {
+            Object version = getProperty(RUNTIME_VERSION);
+            if (version instanceof Version) {
+                return Status.OK_STATUS;
+            }
+            return new Status(Status.ERROR, Activator.PLUGIN_ID, "Must specify SwitchYard runtime version.");
+        }
+        return super.validate(name);
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallWizardPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallWizardPage.java
@@ -1,0 +1,209 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.facets;
+
+import static org.switchyard.tools.ui.M2EUtils.SWITCHYARD_API_ARTIFACT_ID;
+import static org.switchyard.tools.ui.M2EUtils.SWITCHYARD_CORE_GROUP_ID;
+import static org.switchyard.tools.ui.M2EUtils.resolveVersionRange;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.ListViewer;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.m2e.core.internal.index.IndexedArtifactFile;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.wst.common.frameworks.datamodel.IDataModel;
+import org.eclipse.wst.common.project.facet.ui.AbstractFacetWizardPage;
+import org.eclipse.wst.common.project.facet.ui.IFacetWizardPage;
+import org.sonatype.aether.util.artifact.DefaultArtifact;
+import org.sonatype.aether.version.Version;
+import org.switchyard.tools.ui.Activator;
+
+/**
+ * SwitchYardFacetInstallWizardPage
+ * 
+ * Wizard page for configuring SwitchYard facet.
+ * 
+ * @author Rob Cernich
+ */
+@SuppressWarnings("restriction")
+public class SwitchYardFacetInstallWizardPage extends AbstractFacetWizardPage implements IFacetWizardPage,
+        ISwitchYardFacetConstants {
+
+    private boolean _isInitialized;
+    private ListViewer _runtimeVersionsList;
+    private Button _runtimeProvidedCheckbox;
+    private IDataModel _config;
+
+    /**
+     * Create a new SwitchYardFacetInstallWizardPage.
+     */
+    public SwitchYardFacetInstallWizardPage() {
+        super("SwitchYard");
+        setTitle("SwitchYard");
+        setDescription("Configure SwitchYard capabilities on project");
+    }
+
+    @Override
+    public void createControl(Composite parent) {
+        Composite content = new Composite(parent, SWT.NONE);
+        content.setLayout(new GridLayout());
+
+        _runtimeProvidedCheckbox = new Button(content, SWT.CHECK);
+        _runtimeProvidedCheckbox.setText("SwitchYard dependencies provided by runtime");
+        _runtimeProvidedCheckbox.setLayoutData(new GridData());
+        _runtimeProvidedCheckbox.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent event) {
+                _config.setBooleanProperty(RUNTIME_PROVIDED, _runtimeProvidedCheckbox.getSelection());
+                validate();
+            }
+
+        });
+        // not currently supported
+        _runtimeProvidedCheckbox.setVisible(false);
+
+        Label label = new Label(content, SWT.NONE);
+        label.setText("SwitchYard Runtime Version:");
+
+        _runtimeVersionsList = new ListViewer(content, SWT.SINGLE | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
+        _runtimeVersionsList.getList().setLayoutData(new GridData(GridData.FILL_BOTH));
+        _runtimeVersionsList.setLabelProvider(new LabelProvider() {
+            @Override
+            public String getText(Object element) {
+                if (element instanceof IndexedArtifactFile) {
+                    return ((IndexedArtifactFile) element).getArtifactKey().getVersion();
+                }
+                return super.getText(element);
+            }
+        });
+        _runtimeVersionsList.setContentProvider(new ArrayContentProvider());
+        _runtimeVersionsList.addSelectionChangedListener(new ISelectionChangedListener() {
+            @Override
+            public void selectionChanged(SelectionChangedEvent event) {
+                if (event.getSelection().isEmpty()) {
+                    _config.setProperty(RUNTIME_VERSION, null);
+                } else {
+                    _config.setProperty(RUNTIME_VERSION,
+                            (Version) ((IStructuredSelection) event.getSelection()).getFirstElement());
+                }
+                validate();
+            }
+        });
+
+        initControls();
+
+        setControl(content);
+    }
+
+    @Override
+    public void setConfig(Object config) {
+        _config = (IDataModel) config;
+        initControls();
+    }
+    
+    @Override
+    public void setVisible(boolean visible) {
+        if (visible && !_isInitialized) {
+            try {
+                populateRuntimeVersionsList();
+                // clear out any error the first time we are displayed
+                setErrorMessage(null);
+                _isInitialized = true;
+            } catch (CoreException e) {
+                MessageDialog
+                        .openError(getShell(), "Error Populating SwitchYard Runtime Versions",
+                                "An error occurred while trying to resolve SwitchYard runtime versions available from Maven repositories.");
+                Activator.getDefault().getLog().log(e.getStatus());
+            }
+        }
+        super.setVisible(visible);
+    }
+
+    private void initControls() {
+        if (_runtimeProvidedCheckbox == null) {
+            return;
+        }
+        if (_config.isPropertySet(RUNTIME_PROVIDED)) {
+            _runtimeProvidedCheckbox.setSelection(_config.getBooleanProperty(RUNTIME_PROVIDED));
+        } else {
+            _runtimeProvidedCheckbox.setSelection((Boolean) _config.getDefaultProperty(RUNTIME_PROVIDED));
+        }
+        if (_config.isPropertySet(RUNTIME_VERSION)) {
+            _runtimeVersionsList.setSelection(new StructuredSelection(_config.getProperty(RUNTIME_VERSION)), true);
+        }
+    }
+
+    private void populateRuntimeVersionsList() throws CoreException {
+        List<Version> versions = resolveVersionRange(
+                new DefaultArtifact(SWITCHYARD_CORE_GROUP_ID, SWITCHYARD_API_ARTIFACT_ID, "jar", "[,]")).getVersions();
+        Collections.sort(versions, new Comparator<Version>() {
+            @Override
+            public int compare(Version o1, Version o2) {
+                // list the highest version first
+                return -o1.compareTo(o2);
+            }
+        });
+        _runtimeVersionsList.setInput(versions);
+        if (versions.size() > 0) {
+            // TODO: allow use of preferred version or allow association of
+            // server runtime version.
+            _runtimeVersionsList.setSelection(new StructuredSelection(versions.get(0)), true);
+        }
+        validate();
+    }
+    
+    private void validate() {
+        IStatus status = _config.validate();
+        switch (status.getSeverity()) {
+        case IStatus.OK:
+            setErrorMessage(null);
+            break;
+        case IStatus.INFO:
+            setMessage(status.getMessage(), INFORMATION);
+            break;
+        case IStatus.WARNING:
+            setMessage(status.getMessage(), WARNING);
+            break;
+        case IStatus.ERROR:
+        default:
+            setErrorMessage(status.getMessage());
+            break;
+        }
+        setPageComplete(getErrorMessage() == null);
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetUnInstallActionDelegate.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetUnInstallActionDelegate.java
@@ -1,0 +1,49 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.facets;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.wst.common.project.facet.core.IDelegate;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+
+/**
+ * SwitchYardFacetUnInstallActionDelegate
+ * 
+ * Processes the removal of the SwitchYard facet.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardFacetUnInstallActionDelegate implements IDelegate {
+
+    /**
+     * Create a new SwitchYardFacetUnInstallActionDelegate.
+     * 
+     */
+    public SwitchYardFacetUnInstallActionDelegate() {
+    }
+
+    @Override
+    public void execute(IProject project, IProjectFacetVersion fv, Object config, IProgressMonitor monitor)
+            throws CoreException {
+        // we just leave the pom as-is
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/modules/SwitchYardModuleArtifactAdapterDelegate.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/modules/SwitchYardModuleArtifactAdapterDelegate.java
@@ -1,0 +1,68 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.modules;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IModuleArtifact;
+import org.eclipse.wst.server.core.ServerUtil;
+import org.eclipse.wst.server.core.model.ModuleArtifactAdapterDelegate;
+import org.eclipse.wst.server.core.util.NullModuleArtifact;
+
+/**
+ * SwitchYardModuleArtifactAdapterDelegate
+ * 
+ * Adapter delegate used for adapting objects to IModuleArtifact. See extension
+ * point documentation for org.eclipse.wst.server.core.moduleArtifactAdapters.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardModuleArtifactAdapterDelegate extends ModuleArtifactAdapterDelegate {
+
+    /**
+     * Create a new SwitchYardModuleArtifactAdapterDelegate.
+     * 
+     */
+    public SwitchYardModuleArtifactAdapterDelegate() {
+    }
+
+    @Override
+    public IModuleArtifact getModuleArtifact(Object obj) {
+        IResource resource = null;
+        if (obj instanceof IResource) {
+            resource = (IResource) obj;
+        } else if (obj instanceof IAdaptable) {
+            resource = (IResource) ((IAdaptable) obj).getAdapter(IResource.class);
+        }
+        if (resource == null) {
+            resource = (IResource) Platform.getAdapterManager().getAdapter(obj, IResource.class);
+        }
+        if (resource == null) {
+            return null;
+        }
+        IModule module = ServerUtil.getModule(resource.getProject());
+        if (module == null) {
+            return null;
+        }
+        return new NullModuleArtifact(module);
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/AbstractSwitchYardProjectOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/AbstractSwitchYardProjectOperation.java
@@ -60,6 +60,7 @@ public abstract class AbstractSwitchYardProjectOperation implements IWorkspaceRu
 
     private Collection<Dependency> _dependencies;
     private Collection<String> _scanners;
+    private String _switchYardVersion;
     private String _label;
     private boolean _addingServices;
     private IProject _project;
@@ -71,6 +72,7 @@ public abstract class AbstractSwitchYardProjectOperation implements IWorkspaceRu
      * adding service, the switchyard.xml validation will ensure that a
      * composite element exists.
      * 
+     * @param switchYardVersion the version of the SwitchYard dependencies
      * @param requiredDependencies required dependencies.
      * @param requiredScanners required SwitchYard plugin scanners.
      * @param addingServices true if this operation is adding a service to the
@@ -78,8 +80,9 @@ public abstract class AbstractSwitchYardProjectOperation implements IWorkspaceRu
      * @param label monitor task label.
      * @param uiInfo adaptable for UI Shell, may be null.
      */
-    public AbstractSwitchYardProjectOperation(Collection<Dependency> requiredDependencies,
+    public AbstractSwitchYardProjectOperation(String switchYardVersion, Collection<Dependency> requiredDependencies,
             Collection<String> requiredScanners, boolean addingServices, String label, IAdaptable uiInfo) {
+        _switchYardVersion = switchYardVersion;
         _dependencies = requiredDependencies;
         _scanners = requiredScanners;
         _addingServices = addingServices;
@@ -161,7 +164,7 @@ public abstract class AbstractSwitchYardProjectOperation implements IWorkspaceRu
             // update the project's pom
             try {
                 monitor.subTask("Updating project pom.xml file");
-                UpdateProjectPomOperation op = new UpdateProjectPomOperation(_project, _dependencies, _scanners);
+                UpdateProjectPomOperation op = new UpdateProjectPomOperation(_project, _switchYardVersion, _dependencies, _scanners);
                 subMonitor = new SubProgressMonitor(monitor, 100, SubProgressMonitor.PREPEND_MAIN_LABEL_TO_SUBTASK);
                 op.run(subMonitor);
             } catch (CoreException e) {

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateBeanServiceOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateBeanServiceOperation.java
@@ -60,7 +60,7 @@ public class CreateBeanServiceOperation extends AbstractSwitchYardProjectOperati
      */
     public CreateBeanServiceOperation(NewBeanServiceClassWizardPage serviceClassPage,
             NewServiceTestClassWizardPage serviceTestClassPage, IAdaptable uiInfo) {
-        super(DEPENDENCIES, SCANNERS, true, "Creating new SwitchYard bean service.", uiInfo);
+        super(null, DEPENDENCIES, SCANNERS, true, "Creating new SwitchYard bean service.", uiInfo);
         _serviceClassPage = serviceClassPage;
         _serviceTestClassPage = serviceTestClassPage;
     }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateServiceTestOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateServiceTestOperation.java
@@ -49,7 +49,7 @@ public class CreateServiceTestOperation extends AbstractSwitchYardProjectOperati
      * @param uiInfo adaptable for UI Shell, may be null.
      */
     public CreateServiceTestOperation(NewServiceTestClassWizardPage serviceTestClassPage, IAdaptable uiInfo) {
-        super(DEFAULT_DEPENDENCIES, Collections.<String> emptySet(), false, "Creating new SwitchYard bean service.",
+        super(null, DEFAULT_DEPENDENCIES, Collections.<String> emptySet(), false, "Creating new SwitchYard bean service.",
                 uiInfo);
         _serviceTestClassPage = serviceTestClassPage;
     }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateSwitchYardProjectOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateSwitchYardProjectOperation.java
@@ -66,6 +66,7 @@ import org.switchyard.config.OutputKey;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.tools.ui.Activator;
 import org.switchyard.tools.ui.M2EUtils;
+import org.switchyard.tools.ui.facets.ISwitchYardFacetConstants;
 
 /**
  * CreateSwitchYardProjectOperation
@@ -239,7 +240,7 @@ public class CreateSwitchYardProjectOperation implements IWorkspaceRunnable {
 
                 subMonitor = new SubProgressMonitor(monitor, 50, SubProgressMonitor.PREPEND_MAIN_LABEL_TO_SUBTASK);
                 final IFacetedProjectWorkingCopy fpwc = facetedProject.createWorkingCopy();
-                fpwc.setSelectedPreset("org.switchyard.tools.ui.facet.switchYardJarPreset");
+                fpwc.setSelectedPreset(ISwitchYardFacetConstants.SWITCHYARD_JAR_PRESET_ID);
                 fpwc.commitChanges(subMonitor);
             } catch (Exception e) {
                 mergeStatus(status, "Error configuring project facets.", e);

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewSwitchYardProjectWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewSwitchYardProjectWizard.java
@@ -156,7 +156,7 @@ public class NewSwitchYardProjectWizard extends Wizard implements INewWizard {
         String initialProjectName = DEFAULT_PROJECT_NAME;
         int i = 1;
         while (ResourcesPlugin.getWorkspace().getRoot().getProject(initialProjectName).exists()) {
-            initialProjectName = DEFAULT_PROJECT_NAME + i;
+            initialProjectName = DEFAULT_PROJECT_NAME + i++;
         }
         return initialProjectName;
     }

--- a/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/CreateSwitchYardProjectTest.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/CreateSwitchYardProjectTest.java
@@ -107,13 +107,15 @@ public class CreateSwitchYardProjectTest extends AbstractMavenProjectTestCase {
 
         IFacetedProject fp = ProjectFacetsManager.create(newProjectHandle, false, new NullProgressMonitor());
         assertNotNull("Project is not a faceted project.", fp);
+        assertTrue("switchyard.core facet not configured on project",
+                fp.hasProjectFacet(ProjectFacetsManager.getProjectFacet("switchyard.core")));
         assertTrue("jst.utility facet not configured on project",
                 fp.hasProjectFacet(ProjectFacetsManager.getProjectFacet("jst.utility")));
         assertTrue("java facet not configured on project",
                 fp.hasProjectFacet(ProjectFacetsManager.getProjectFacet("java")));
 
         // Test project update
-        op = new AbstractSwitchYardProjectOperation(Collections.singleton(M2EUtils.createSwitchYardDependency(
+        op = new AbstractSwitchYardProjectOperation(null, Collections.singleton(M2EUtils.createSwitchYardDependency(
                 "org.switchyard.components", "switchyard-component-bpm")), Collections.<String> emptySet(), true,
                 "Testing SwitchYard project update", null) {
 


### PR DESCRIPTION
Adds a simple facet for identifying SY projects.
Added module factory to support "Run as -> Run on Server" for SY projects.
Updated m2e integration to add SY facet when importing Maven projects.

Outstanding issues:
Utility Module facet adds META-INF/MANIFEST.MF in the first source directory.  This should be fixed in the Eclipse framework or WTP m2e integration.
Repositories are not added when adding the SY facet to an existing project or through the new faceted project wizard (i.e. the user may see dependency errors).
No facet support for components (i.e. you still have to add component dependencies manually).
For a typical Java SY project "Deployables" are not initialized correctly after first importing or creating a SY project (i.e. the test source and resources are included).  The user must run Maven->Update Project Configuration after import/creation to fix the problem.  (This is an issue with m2e integration where the "utility module" configurator is executed before the SY configurator, which adds the utility module facet.)
