### PR TITLE
SWITCHYARD-554 enable configuration of SwitchYard components on a

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
@@ -20,9 +20,15 @@ Require-Bundle: org.eclipse.ui,
  org.switchyard.tools.core;bundle-version="0.4.0",
  org.eclipse.wst.server.core;bundle-version="1.1.0",
  org.eclipse.jst.jee;bundle-version="1.0.0",
- org.eclipse.jst.j2ee;bundle-version="1.1.0"
+ org.eclipse.jst.j2ee;bundle-version="1.1.0",
+ org.eclipse.m2e.core.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: org.switchyard.tools.ui,
+ org.switchyard.tools.ui.actions,
+ org.switchyard.tools.ui.common,
+ org.switchyard.tools.ui.common.impl,
+ org.switchyard.tools.ui.facets,
  org.switchyard.tools.ui.operations,
+ org.switchyard.tools.ui.properties,
  org.switchyard.tools.ui.wizards

--- a/eclipse/plugins/org.switchyard.tools.ui/build.properties
+++ b/eclipse/plugins/org.switchyard.tools.ui/build.properties
@@ -3,7 +3,8 @@ output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               icons/
+               icons/,\
+               schema/
 additional.bundles = org.eclipse.ui,\
                      org.eclipse.ui.cheatsheets,\
                      org.eclipse.ui.editors,\
@@ -18,7 +19,6 @@ additional.bundles = org.eclipse.ui,\
                      org.eclipse.ui.workbench,\
                      org.eclipse.ui.workbench.texteditor,\
                      org.eclipse.m2e.core,\
-                     org.eclipse.m2e.core.ui,\
                      org.eclipse.m2e.jdt,\
                      org.eclipse.m2e.maven.runtime,\
                      org.eclipse.jdt,\

--- a/eclipse/plugins/org.switchyard.tools.ui/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
+   <extension-point id="switchYardComponent" name="SwitchYardComponent" schema="schema/switchYardComponent.exsd"/>
    <extension
          point="org.eclipse.ui.newWizards">
       <category
@@ -208,6 +209,167 @@
                 </adapt>
              </with></enablement>
      </moduleArtifactAdapter>
+  </extension>
+  <extension point="org.eclipse.wst.server.ui.serverImages">
+    <image 
+      id="org.switchyard.tools.switchyard.core"
+      typeIds="switchyard.core" 
+      icon="icons/switchyard_icon_16px.png"/>
+  </extension>
+  <extension
+        point="org.eclipse.ui.propertyPages">
+     <page
+           category="org.eclipse.wst.common.project.facet.ui.FacetsPropertyPage"
+           class="org.switchyard.tools.ui.properties.SwitchYardSettingsPropertyPage"
+           id="org.switchyard.tools.ui.configuration.page"
+           name="SwitchYard Settings"
+           selectionFilter="single">
+        <enabledWhen>
+           <adapt
+                 type="org.eclipse.core.resources.IProject">
+              <test
+                    property="org.eclipse.wst.common.project.facet.core.projectFacet"
+                    value="switchyard.core">
+              </test>
+           </adapt>
+        </enabledWhen>
+     </page>
+  </extension>
+  <extension
+        point="org.eclipse.ui.popupMenus">
+     <objectContribution
+           adaptable="true"
+           id="org.switchyard.tools.ui.configuration.menu"
+           objectClass="org.eclipse.core.resources.IProject">
+        <action
+              class="org.switchyard.tools.ui.actions.SwitchYardSettingsAction"
+              enablesFor="1"
+              id="org.switchyard.tools.ui.configuration.action.settings"
+              label="SwitchYard Capabilities..."
+              menubarPath="org.eclipse.ui.projectConfigure/additions">
+        </action>
+        <visibility>
+           <objectState
+                 name="projectNature"
+                 value="org.eclipse.m2e.core.maven2Nature">
+           </objectState>
+        </visibility>
+     </objectContribution>
+  </extension>
+  <extension
+        point="org.switchyard.tools.ui.switchYardComponent">
+     <component
+           id="org.switchyard:switchyard-runtime"
+           name="Runtime"
+           scannerClass="org.switchyard.transform.config.model.TransformSwitchYardScanner">
+        <description>
+           Core SwitchYard runtime dependencies.
+        </description>
+        <dependency>
+           <groupId>org.switchyard</groupId>
+           <artifactId>switchyard-api</artifactId>
+        </dependency>
+        <dependency>
+           <groupId>org.switchyard</groupId>
+           <artifactId>switchyard-plugin</artifactId>
+        </dependency>
+        <dependency>
+           <groupId>org.switchyard</groupId>
+           <artifactId>switchyard-test</artifactId>
+        </dependency>
+     </component>
+     <component
+           id="org.switchyard.components:switchyard-component-bean"
+           name="Bean"
+           scannerClass="org.switchyard.component.bean.config.model.BeanSwitchYardScanner">
+        <description>
+           Provides support for Java based service implementations.
+        </description>
+        <dependency>
+           <groupId>org.switchyard.components</groupId>
+           <artifactId>switchyard-component-bean</artifactId>
+        </dependency>
+     </component>
+     <component
+           name="BPEL"
+           id="org.switchyard.components:switchyard-component-bpel">
+        <description>
+           Provides support for BPEL based service implementations.
+        </description>
+        <dependency>
+           <groupId>org.switchyard.components</groupId>
+           <artifactId>switchyard-component-bpel</artifactId>
+        </dependency>
+     </component>
+     <component
+           id="org.switchyard.components:switchyard-component-bpm"
+           name="BPM (jBPM)"
+           scannerClass="org.switchyard.component.bpm.config.model.BPMSwitchYardScanner">
+        <description>
+           Provides support for BPM based service implementations.
+        </description>
+        <dependency>
+           <groupId>org.switchyard.components</groupId>
+           <artifactId>switchyard-component-bpm</artifactId>
+        </dependency>
+     </component>
+     <component
+           id="org.switchyard.components:switchyard-component-camel"
+           name="Camel"
+           scannerClass="org.switchyard.component.camel.config.model.RouteScanner">
+        <description>
+           Provides support for Camel based service implementations and Camel based gateways.
+        </description>
+        <dependency>
+           <groupId>org.switchyard.components</groupId>
+           <artifactId>switchyard-component-camel</artifactId>
+        </dependency>
+     </component>
+     <component
+           name="Clojure"
+           id="org.switchyard.components:switchyard-component-clojure">
+        <description>
+           Provides support for Clojure based service implementations.
+        </description>
+        <dependency>
+           <groupId>org.switchyard.components</groupId>
+           <artifactId>switchyard-component-clojure</artifactId>
+        </dependency>
+     </component>
+     <component
+           name="HornetQ"
+           id="org.switchyard.components:switchyard-component-hornetq">
+        <description>
+           Provides support for HornetQ based gateways.
+        </description>
+        <dependency>
+           <groupId>org.switchyard.components</groupId>
+           <artifactId>switchyard-component-hornetq</artifactId>
+        </dependency>
+     </component>
+     <component
+           id="org.switchyard.components:switchyard-component-rules"
+           name="Rules (Drools)"
+           scannerClass="org.switchyard.component.rules.config.model.RulesSwitchYardScanner">
+        <description>
+           Provides support for Drools based service implementations.
+        </description>
+        <dependency>
+           <groupId>org.switchyard.components</groupId>
+           <artifactId>switchyard-component-rules</artifactId>
+        </dependency>
+     </component>
+     <component
+           id="org.switchyard.components:switchyard-component-soap"
+           name="SOAP">
+        <description>
+           Provides support for SOAP based gateways.
+        </description>
+        <dependency>
+           <groupId>org.switchyard.components</groupId>
+           <artifactId>switchyard-component-soap</artifactId>
+        </dependency>
+     </component>
   </extension>
 
 </plugin>

--- a/eclipse/plugins/org.switchyard.tools.ui/schema/switchYardComponent.exsd
+++ b/eclipse/plugins/org.switchyard.tools.ui/schema/switchYardComponent.exsd
@@ -1,0 +1,159 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.switchyard.tools.ui" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.switchyard.tools.ui" id="switchYardComponent" name="SwitchYardComponent"/>
+      </appinfo>
+      <documentation>
+         This extension point is used for contributing SwitchYard component types with the tooling.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="component"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="component">
+      <complexType>
+         <sequence>
+            <element ref="description" minOccurs="0" maxOccurs="1"/>
+            <element ref="dependency" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The text to display for this component.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  the ID used for referencing this component.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="identifier"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="scannerClass" type="string">
+            <annotation>
+               <documentation>
+                  The name of a scanner class that should be added to the SwitchYard configuration plugin.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="dependency">
+      <annotation>
+         <documentation>
+            Represents a required SwitchYard dependency for the component.
+         </documentation>
+      </annotation>
+      <complexType>
+         <choice>
+            <sequence>
+               <element ref="artifactId"/>
+               <element ref="groupId"/>
+            </sequence>
+            <sequence>
+               <element ref="groupId"/>
+               <element ref="artifactId"/>
+            </sequence>
+         </choice>
+      </complexType>
+   </element>
+
+   <element name="artifactId" type="string">
+      <annotation>
+         <documentation>
+            The Maven artifactId for the dependency.
+         </documentation>
+      </annotation>
+   </element>
+
+   <element name="groupId" type="string">
+      <annotation>
+         <documentation>
+            The Maven groupId for the dependency.
+         </documentation>
+      </annotation>
+   </element>
+
+   <element name="description" type="string">
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/actions/SwitchYardSettingsAction.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/actions/SwitchYardSettingsAction.java
@@ -1,0 +1,231 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.actions;
+
+import static org.switchyard.tools.ui.facets.ISwitchYardFacetConstants.SWITCHYARD_BASIC_PRESET_ID;
+import static org.switchyard.tools.ui.facets.ISwitchYardFacetConstants.SWITCHYARD_FACET;
+import static org.switchyard.tools.ui.facets.ISwitchYardFacetConstants.SWITCHYARD_JAR_PRESET_ID;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.operation.IRunnableWithProgress;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.IWizardPage;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.ui.IObjectActionDelegate;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.actions.ActionDelegate;
+import org.eclipse.ui.dialogs.PreferencesUtil;
+import org.eclipse.wst.common.frameworks.datamodel.IDataModel;
+import org.eclipse.wst.common.project.facet.core.IFacetedProject;
+import org.eclipse.wst.common.project.facet.core.IFacetedProjectWorkingCopy;
+import org.eclipse.wst.common.project.facet.core.IPreset;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.eclipse.wst.common.project.facet.ui.ModifyFacetedProjectWizard;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.facets.ISwitchYardFacetConstants;
+import org.switchyard.tools.ui.facets.SwitchYardFacetInstallWizardPage;
+
+/**
+ * SwitchYardSettingsAction
+ * 
+ * <p/>
+ * Action implementation for opening SwitchYard settings. If the project is not
+ * a SwitchYard project, the user is asked if they would like to add the
+ * SwitchYard facet.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardSettingsAction extends ActionDelegate implements IObjectActionDelegate {
+
+    private IProject _project;
+    private IWorkbenchPart _targetPart;
+
+    @Override
+    public void setActivePart(IAction action, IWorkbenchPart targetPart) {
+        _targetPart = targetPart;
+    }
+
+    @Override
+    public void run(IAction action) {
+        try {
+            internalRun();
+        } catch (CoreException e) {
+            Activator.getDefault().getLog().log(e.getStatus());
+        }
+    }
+
+    private void internalRun() throws CoreException {
+        if (_project == null || _targetPart == null) {
+            return;
+        }
+
+        // check to see if this is a faceted project
+        IFacetedProject ifp = ProjectFacetsManager.create(_project);
+        if (ifp == null) {
+            // prompt user to add SwitchYard and convert to faceted project.
+            if (MessageDialog
+                    .openQuestion(
+                            _targetPart.getSite().getShell(),
+                            "Add SwitchYard Capabilities?",
+                            "The selected project is not a SwitchYard project.\n\nDo you wish to add SwitchYard capabilities?\n\n* Note, this will convert the project to Faceted Form.")) {
+                convertToFacetedProject();
+            }
+            return;
+        } else if (!ifp.hasProjectFacet(SWITCHYARD_FACET)) {
+            // check to see if SwitchYard is installed
+            if (MessageDialog.openQuestion(_targetPart.getSite().getShell(), "Add SwitchYard Capabilities?",
+                    "The selected project is not a SwitchYard project.\n\nDo you wish to add SwitchYard capabilities?")) {
+                installSwitchYardFacet(ifp.createWorkingCopy());
+            }
+            return;
+        }
+
+        displayPropertyDialog();
+    }
+
+    private void convertToFacetedProject() throws CoreException {
+        IFacetedProject ifp = ProjectFacetsManager.create(_project, true, new NullProgressMonitor());
+        installSwitchYardFacet(ifp.createWorkingCopy());
+    }
+
+    private void installSwitchYardFacet(final IFacetedProjectWorkingCopy fpwc) {
+        try {
+            boolean installed = false;
+            final String installPresetId;
+            if (isJarPackaging()) {
+                installPresetId = SWITCHYARD_JAR_PRESET_ID;
+            } else {
+                installPresetId = SWITCHYARD_BASIC_PRESET_ID;
+            }
+            for (IPreset preset : fpwc.getAvailablePresets()) {
+                if (installPresetId.equals(preset.getId())) {
+                    // this should setup the java facet correctly
+                    for (IProjectFacetVersion pfv : preset.getProjectFacets()) {
+                        fpwc.addProjectFacet(pfv);
+                    }
+                    installed = true;
+                    break;
+                }
+            }
+            if (!installed) {
+                // TODO: maybe show an error saying we couldn't install the sy
+                // facet.
+                return;
+            }
+            if (fpwc.getProjectFacetAction(SWITCHYARD_FACET) != null) {
+                Object config = fpwc.getProjectFacetAction(SWITCHYARD_FACET).getConfig();
+                if (config instanceof IDataModel
+                        && !((IDataModel) config).isPropertySet(ISwitchYardFacetConstants.RUNTIME_VERSION)) {
+                    // display the wizard if the project doesn't have SY
+                    // capabilities
+                    ModifyFacetedProjectWizard modifyWizard = new ModifyFacetedProjectWizard(fpwc) {
+                        @Override
+                        public IWizardPage[] getPages() {
+                            // we only need to configure switchyard
+                            for (IWizardPage page : super.getPages()) {
+                                if (page instanceof SwitchYardFacetInstallWizardPage) {
+                                    return new IWizardPage[] {page };
+                                }
+                            }
+                            return new IWizardPage[0];
+                        }
+                    };
+                    modifyWizard.setShowFacetsSelectionPage(false);
+                    WizardDialog dialog = new WizardDialog(_targetPart.getSite().getShell(), modifyWizard);
+                    dialog.setBlockOnOpen(true);
+                    dialog.open();
+                    // no need to go to open the property page, since the user
+                    // just edited the settings
+                    return;
+                }
+            }
+
+            // install the facet
+            try {
+                PlatformUI.getWorkbench().getProgressService().run(false, true, new IRunnableWithProgress() {
+                    @Override
+                    public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+                        try {
+                            fpwc.commitChanges(monitor);
+                        } catch (CoreException e) {
+                            throw new InvocationTargetException(e);
+                        }
+                    }
+                });
+            } catch (Exception e) {
+                if (e.getCause() instanceof CoreException) {
+                    Activator.getDefault().getLog().log(((CoreException) e.getCause()).getStatus());
+                } else {
+                    Activator
+                            .getDefault()
+                            .getLog()
+                            .log(new Status(Status.ERROR, Activator.PLUGIN_ID, "Error initializing SwitchYard facet.",
+                                    e));
+                }
+            }
+            displayPropertyDialog();
+        } finally {
+            fpwc.dispose();
+        }
+    }
+
+    private boolean isJarPackaging() {
+        final IMavenProjectFacade mavenFacade = MavenPlugin.getMavenProjectRegistry().getProject(_project);
+        return mavenFacade == null || "jar".equals(mavenFacade.getPackaging());
+    }
+
+    @Override
+    public void selectionChanged(IAction action, ISelection selection) {
+        super.selectionChanged(action, selection);
+        _project = null;
+        if (selection.isEmpty() || !(selection instanceof IStructuredSelection)) {
+            return;
+        }
+        Object obj = ((IStructuredSelection) selection).getFirstElement();
+        if (obj instanceof IProject) {
+            _project = (IProject) obj;
+        }
+    }
+
+    @Override
+    public void dispose() {
+        _project = null;
+        _targetPart = null;
+        super.dispose();
+    }
+
+    private void displayPropertyDialog() {
+        // display project properties dialog, open to SwitchYard Settings
+        PreferencesUtil.createPropertyDialogOn(_targetPart.getSite().getShell(), _project,
+                "org.switchyard.tools.ui.configuration.page", null, null, PreferencesUtil.OPTION_NONE).open();
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ILayoutUtilities.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ILayoutUtilities.java
@@ -1,0 +1,42 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.common;
+
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+
+/**
+ * ILayoutUtilities
+ * 
+ * <p/>
+ * Simple interface providing layout utilities.
+ * 
+ * @author Rob Cernich
+ */
+public interface ILayoutUtilities {
+
+    /**
+     * Takes care of setting the button's layout data.
+     * 
+     * @param button the button
+     * @return the layout data set on the button.
+     */
+    public GridData setButtonLayoutData(Button button);
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ISwitchYardComponentExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ISwitchYardComponentExtension.java
@@ -1,0 +1,61 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.common;
+
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+
+/**
+ * ISwitchYardComponentExtension
+ * 
+ * <p/>
+ * Represents an instance of an org.switchyard.tools.ui.switchYardComponent
+ * extension.
+ * 
+ * @author Rob Cernich
+ */
+public interface ISwitchYardComponentExtension {
+
+    /**
+     * @return the ID of this component.
+     */
+    public String getId();
+
+    /**
+     * @return the display name for this component.
+     */
+    public String getName();
+
+    /**
+     * @return the description of this component.
+     */
+    public String getDescription();
+
+    /**
+     * @return the name of a scanner class associated with this component, if
+     *         any.
+     */
+    public String getScannerClassName();
+
+    /**
+     * @return the Maven dependencies required by this component.
+     */
+    public List<Dependency> getDependencies();
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ISwitchYardProject.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ISwitchYardProject.java
@@ -1,0 +1,92 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.common;
+
+import java.util.Set;
+
+import org.apache.maven.project.MavenProject;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * ISwitchYardProject
+ * 
+ * <p/>
+ * Represents a SwitchYard project. Wraps and provides accessors for SwitchYard
+ * specific meta-data.
+ * 
+ * @author Rob Cernich
+ */
+public interface ISwitchYardProject {
+
+    /**
+     * @return the underlying project.
+     */
+    IProject getProject();
+
+    /**
+     * @return the associated Maven project.
+     */
+    MavenProject getMavenProject();
+
+    /**
+     * @return the SwitchYard version.
+     */
+    String getVersion();
+
+    /**
+     * @return the property key used to define the SwitchYard version.
+     */
+    String getVersionPropertyKey();
+
+    /**
+     * @return the components configured on the project.
+     */
+    Set<ISwitchYardComponentExtension> getComponents();
+
+    /**
+     * @return true if dependencies are resolved using dependency management
+     *         (i.e. getRawVersionString() == null).
+     */
+    boolean isUsingDependencyManagement();
+
+    /**
+     * @return the raw version string (e.g. ${switchyard.version}); may be null;
+     */
+    String getRawVersionString();
+
+    /**
+     * @return true if the meta-data for this project needs to be updated.
+     */
+    boolean needsLoading();
+
+    /**
+     * Force loading of project meta-data. This may be a long running operation
+     * depending on whether or not Maven project meta-data has been cached (i.e.
+     * this may force a load of the Maven meta-data).
+     * 
+     * @param monitor the progress monitor.
+     */
+    void load(IProgressMonitor monitor);
+
+    /**
+     * @return a working copy for making changes to SwitchYard settings.
+     */
+    ISwitchYardProjectWorkingCopy createWorkingCopy();
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ISwitchYardProjectWorkingCopy.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ISwitchYardProjectWorkingCopy.java
@@ -1,0 +1,85 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.common;
+
+import java.util.Collection;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * ISwitchYardProjectWorkingCopy
+ * 
+ * <p/>
+ * Manages modifications to a SwitchYard project.
+ * 
+ * @author Rob Cernich
+ */
+public interface ISwitchYardProjectWorkingCopy extends ISwitchYardProject {
+
+    /**
+     * @param version the new version.
+     */
+    void setRuntimeVersion(String version);
+
+    /**
+     * @param component the component to add.
+     */
+    void addComponent(ISwitchYardComponentExtension component);
+
+    /**
+     * @param components the components to add.
+     */
+    void addComponents(Collection<ISwitchYardComponentExtension> components);
+
+    /**
+     * @param component the component to remove.
+     */
+    void removeComponent(ISwitchYardComponentExtension component);
+
+    /**
+     * @param components the components to remove.
+     */
+    void removeComponents(Collection<ISwitchYardComponentExtension> components);
+
+    /**
+     * @return true if any SwitchYard settings have been modified.
+     */
+    boolean isModified();
+
+    /**
+     * Incorporates any changes into the project's pom.xml. If the commit
+     * operation is successful, isModified() will return false.
+     * 
+     * @param monitor the progress monitor.
+     * @throws CoreException if something goes awry.
+     */
+    void commit(IProgressMonitor monitor) throws CoreException;
+
+    /**
+     * Resets any changes made to this working copy. After calling this method,
+     * isModified() will return false.
+     */
+    void revert();
+
+    /**
+     * Releases resources held by the working copy.
+     */
+    void dispose();
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/SwitchYardComponentExtensionManager.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/SwitchYardComponentExtensionManager.java
@@ -1,0 +1,240 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.common;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.maven.model.Dependency;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.M2EUtils;
+
+/**
+ * SwitchYardComponentExtensionManager
+ * 
+ * <p/>
+ * Manages the org.switchyard.tools.ui.switchYardComponent extension point.
+ * 
+ * @author Rob Cernich
+ */
+public final class SwitchYardComponentExtensionManager {
+
+    /** The ID of the core SwitchYard runtime component. */
+    public static final String RUNTIME_COMPONENT_EXTENSION_ID = "org.switchyard:switchyard-runtime";
+
+    private static final SwitchYardComponentExtensionManager INSTANCE = new SwitchYardComponentExtensionManager();
+
+    /**
+     * @return the instance.
+     */
+    public static SwitchYardComponentExtensionManager instance() {
+        return INSTANCE;
+    }
+
+    private Map<String, ISwitchYardComponentExtension> _extensions = new TreeMap<String, ISwitchYardComponentExtension>();
+
+    private SwitchYardComponentExtensionManager() {
+        IExtensionPoint extensionPoint = Platform.getExtensionRegistry().getExtensionPoint(Activator.PLUGIN_ID,
+                "switchYardComponent");
+        for (IExtension extension : extensionPoint.getExtensions()) {
+            for (IConfigurationElement element : extension.getConfigurationElements()) {
+                processComponent(element);
+            }
+        }
+    }
+
+    /**
+     * @return the extension representing the core runtime.
+     */
+    public ISwitchYardComponentExtension getRuntimeComponentExtension() {
+        if (_extensions.containsKey(RUNTIME_COMPONENT_EXTENSION_ID)) {
+            return _extensions.get(RUNTIME_COMPONENT_EXTENSION_ID);
+        }
+        return null;
+    }
+
+    /**
+     * @return the list of registered component extensions.
+     */
+    public Collection<ISwitchYardComponentExtension> getComponentExtensions() {
+        return Collections.unmodifiableCollection(_extensions.values());
+    }
+
+    /**
+     * @param id the id of the component extension.
+     * @return the component extension; null if no extension is registered with
+     *         the specified id.
+     */
+    public ISwitchYardComponentExtension getComponentExtension(String id) {
+        if (_extensions.containsKey(id)) {
+            return _extensions.get(id);
+        }
+        return null;
+    }
+
+    private void processComponent(IConfigurationElement element) {
+        if (!"component".equals(element.getName())) {
+            Activator
+                    .getDefault()
+                    .getLog()
+                    .log(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                            "Invalid element in switchYardComponent extension: element=" + element.getName()
+                                    + ", plugin=" + element.getContributor().getName()));
+            return;
+        }
+        String id = element.getAttribute("id");
+        String name = element.getAttribute("name");
+        String description = parseDescription(element);
+        List<Dependency> dependencies = parseDependencies(element);
+        if (id == null) {
+            Activator
+                    .getDefault()
+                    .getLog()
+                    .log(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                            "Invalid \"id\" must be specified in switchYardComponent extension: plugin="
+                                    + element.getContributor().getName()));
+            return;
+        } else if (_extensions.containsKey(id)) {
+            Activator
+                    .getDefault()
+                    .getLog()
+                    .log(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                            "Duplicate \"id\" specified in switchYardComponent extension: plugin="
+                                    + element.getContributor().getName()));
+            return;
+        } else if (name == null || name.length() == 0) {
+            name = id;
+        }
+        _extensions.put(id, new SwitchYardComponentExtension(id, name, element.getAttribute("scannerClass"),
+                description, dependencies));
+    }
+
+    private String parseDescription(IConfigurationElement element) {
+        IConfigurationElement[] descriptions = element.getChildren("description");
+        if (descriptions.length == 0) {
+            return null;
+        }
+        return descriptions[0].getValue();
+    }
+
+    private List<Dependency> parseDependencies(IConfigurationElement element) {
+        IConfigurationElement[] dependencyElements = element.getChildren("dependency");
+        if (dependencyElements == null) {
+            return Collections.emptyList();
+        }
+        List<Dependency> dependencies = new ArrayList<Dependency>(dependencyElements.length);
+        for (IConfigurationElement dependencyElement : dependencyElements) {
+            String artifactId = parseArtifactId(dependencyElement);
+            String groupId = parseGroupId(dependencyElement);
+            if (artifactId == null || artifactId.length() == 0 || groupId == null || groupId.length() == 0) {
+                Activator
+                        .getDefault()
+                        .getLog()
+                        .log(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                                "Invalid dependency in switchYardComponent extension: plugin="
+                                        + element.getContributor().getName()));
+                continue;
+            }
+            dependencies.add(M2EUtils.createSwitchYardDependency(groupId, artifactId));
+        }
+        return dependencies;
+    }
+
+    private String parseGroupId(IConfigurationElement element) {
+        IConfigurationElement[] groupIds = element.getChildren("groupId");
+        if (groupIds.length != 1) {
+            Activator
+                    .getDefault()
+                    .getLog()
+                    .log(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                            "Only one \"groupId\" element may be specified in a \"dependency\" for a switchYardComponent extension: plugin="
+                                    + element.getContributor().getName()));
+            return null;
+        }
+        return groupIds[0].getValue().trim();
+    }
+
+    private String parseArtifactId(IConfigurationElement element) {
+        IConfigurationElement[] artifactIds = element.getChildren("artifactId");
+        if (artifactIds.length != 1) {
+            Activator
+                    .getDefault()
+                    .getLog()
+                    .log(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                            "Only one \"artifactId\" element may be specified in a \"dependency\" for a switchYardComponent extension: plugin="
+                                    + element.getContributor().getName()));
+            return null;
+        }
+        return artifactIds[0].getValue().trim();
+    }
+
+    private static final class SwitchYardComponentExtension implements ISwitchYardComponentExtension {
+
+        private final String _id;
+        private final String _name;
+        private final String _scannerClassName;
+        private final String _description;
+        private final List<Dependency> _dependencies;
+
+        private SwitchYardComponentExtension(String id, String name, String scannerClassName, String description,
+                List<Dependency> dependencies) {
+            super();
+            _id = id;
+            _name = name;
+            _scannerClassName = scannerClassName;
+            _description = description;
+            _dependencies = Collections.unmodifiableList(dependencies);
+        }
+
+        @Override
+        public String getId() {
+            return _id;
+        }
+
+        @Override
+        public String getName() {
+            return _name;
+        }
+
+        @Override
+        public String getScannerClassName() {
+            return _scannerClassName;
+        }
+
+        @Override
+        public String getDescription() {
+            return _description;
+        }
+
+        @Override
+        public List<Dependency> getDependencies() {
+            return _dependencies;
+        }
+
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/SwitchYardSettingsGroup.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/SwitchYardSettingsGroup.java
@@ -1,0 +1,286 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.common;
+
+import static org.switchyard.tools.ui.M2EUtils.resolveSwitchYardVersionRange;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.jface.operation.IRunnableContext;
+import org.eclipse.jface.operation.IRunnableWithProgress;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.CheckboxTableViewer;
+import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+import org.sonatype.aether.version.Version;
+import org.switchyard.tools.ui.Activator;
+
+/**
+ * SwitchYardSettingsGroup
+ * 
+ * <p/>
+ * Controls for editing/viewing for SwitchYard settings.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardSettingsGroup {
+
+    private IRunnableContext _context;
+    private ComboViewer _runtimeVersionsList;
+    private Button _runtimeProvidedCheckbox;
+    private CheckboxTableViewer _componentsTable;
+    private Text _descriptionText;
+    private List<Version> _availableVersions;
+
+    /**
+     * Create a new SwitchYardSettingsGroup.
+     * 
+     * @param parent the parent composite
+     * @param layoutUtilities utilities to help with layout.
+     * @param context a runnable context to use for long running operations.
+     */
+    public SwitchYardSettingsGroup(Composite parent, ILayoutUtilities layoutUtilities, IRunnableContext context) {
+        super();
+        _context = context;
+
+        Composite runtimeControls = new Composite(parent, SWT.NONE);
+        runtimeControls.setLayout(new GridLayout(2, false));
+        runtimeControls.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+        Label label = new Label(runtimeControls, SWT.NONE);
+        label.setText("Runtime Version:");
+
+        _runtimeVersionsList = new ComboViewer(runtimeControls, SWT.DROP_DOWN | SWT.READ_ONLY);
+        _runtimeVersionsList.getCombo().setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        _runtimeVersionsList.setLabelProvider(new LabelProvider());
+        _runtimeVersionsList.setContentProvider(ArrayContentProvider.getInstance());
+
+        Composite componentsControls = new Composite(parent, SWT.NONE);
+        componentsControls.setLayout(new GridLayout());
+        componentsControls.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+        _runtimeProvidedCheckbox = new Button(componentsControls, SWT.CHECK);
+        _runtimeProvidedCheckbox.setText("SwitchYard dependencies provided by container");
+        _runtimeProvidedCheckbox.setLayoutData(new GridData());
+        // not currently supported
+        _runtimeProvidedCheckbox.setVisible(false);
+
+        label = new Label(componentsControls, SWT.NONE);
+        label.setText("Components:");
+
+        _componentsTable = CheckboxTableViewer.newCheckList(componentsControls, SWT.SINGLE | SWT.BORDER | SWT.V_SCROLL
+                | SWT.V_SCROLL);
+        _componentsTable.setLabelProvider(new LabelProvider() {
+            public String getText(Object element) {
+                if (element instanceof ISwitchYardComponentExtension) {
+                    return ((ISwitchYardComponentExtension) element).getName();
+                }
+                return super.getText(element);
+            }
+        });
+        _componentsTable.setContentProvider(ArrayContentProvider.getInstance());
+        _componentsTable.getTable().setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        _componentsTable.addSelectionChangedListener(new ISelectionChangedListener() {
+            @Override
+            public void selectionChanged(SelectionChangedEvent event) {
+                ISelection selection = _componentsTable.getSelection();
+                if (selection instanceof IStructuredSelection && !selection.isEmpty()) {
+                    String description = ((ISwitchYardComponentExtension) ((IStructuredSelection) selection)
+                            .getFirstElement()).getDescription();
+                    if (description == null || description.length() == 0) {
+                        description = "unavailable";
+                    }
+                    _descriptionText.setText(description);
+                } else {
+                    _descriptionText.setText("");
+                }
+            }
+        });
+        _componentsTable.addFilter(new ViewerFilter() {
+            private final Object _runtimeComponent = SwitchYardComponentExtensionManager.instance()
+                    .getRuntimeComponentExtension();
+
+            @Override
+            public boolean select(Viewer viewer, Object parentElement, Object element) {
+                return element != _runtimeComponent;
+            }
+        });
+
+        Composite buttonControls = new Composite(componentsControls, SWT.NONE);
+        buttonControls.setLayout(new GridLayout(2, true));
+        buttonControls.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+        Button selectAll = new Button(buttonControls, SWT.PUSH);
+        layoutUtilities.setButtonLayoutData(selectAll);
+        selectAll.setText("&Select All");
+        selectAll.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent event) {
+                selectAllComponents();
+            }
+        });
+
+        Button deselectAll = new Button(buttonControls, SWT.PUSH);
+        layoutUtilities.setButtonLayoutData(deselectAll);
+        deselectAll.setText("&Deselect All");
+        deselectAll.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent event) {
+                deselectAllComponents();
+            }
+        });
+
+        Group detailsGroup = new Group(parent, SWT.NONE);
+        detailsGroup.setText("Component Description");
+        detailsGroup.setLayout(new GridLayout());
+        detailsGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+        _descriptionText = new Text(detailsGroup, SWT.READ_ONLY | SWT.WRAP | SWT.MULTI | SWT.V_SCROLL | SWT.V_SCROLL);
+        GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+        gd.heightHint = _descriptionText.getLineHeight() * 3;
+        _descriptionText.setLayoutData(gd);
+
+        initControls();
+    }
+
+    /**
+     * @return the available SwitchYard runtime versions.
+     */
+    public List<Version> getAvailableVersions() {
+        return _availableVersions;
+    }
+
+    /**
+     * @return the components viewer.
+     */
+    public CheckboxTableViewer getComponentsTable() {
+        return _componentsTable;
+    }
+
+    /**
+     * @return the runtime versions viewer.
+     */
+    public StructuredViewer getRuntimeVersionsList() {
+        return _runtimeVersionsList;
+    }
+
+    /**
+     * @return the runtime provided checkbox.
+     */
+    public Button getRuntimeProvidedCheckbox() {
+        return _runtimeProvidedCheckbox;
+    }
+
+    /**
+     * @return components added by the user.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes" })
+    public Set<ISwitchYardComponentExtension> getSelectedComponents() {
+        Set<ISwitchYardComponentExtension> selectedComponents = new LinkedHashSet<ISwitchYardComponentExtension>(
+                (List) Arrays.asList(_componentsTable.getCheckedElements()));
+        selectedComponents.add(SwitchYardComponentExtensionManager.instance().getRuntimeComponentExtension());
+        return selectedComponents;
+    }
+
+    private void initControls() {
+        try {
+            _context.run(false, true, new IRunnableWithProgress() {
+                @Override
+                public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+                    monitor.beginTask("Loading available SwitchYard capabilities.", 100);
+                    try {
+                        populateComponentsTable();
+                        monitor.worked(50);
+                        populateRuntimeVersionsList(new SubProgressMonitor(monitor, 50));
+                    } catch (CoreException e) {
+                        throw new InvocationTargetException(e);
+                    } finally {
+                        monitor.done();
+                    }
+                }
+            });
+        } catch (Exception e) {
+            if (e.getCause() instanceof CoreException) {
+                Activator
+                        .getDefault()
+                        .getLog()
+                        .log(new MultiStatus(Activator.PLUGIN_ID, -1, new IStatus[] {((CoreException) e.getCause())
+                                .getStatus() }, "Error loading available SwitchYard capabilities.", e));
+            } else {
+                Activator
+                        .getDefault()
+                        .getLog()
+                        .log(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                                "Error loading available SwitchYard capabilities.", e));
+            }
+        }
+    }
+
+    private void populateRuntimeVersionsList(IProgressMonitor monitor) throws CoreException {
+        _availableVersions = resolveSwitchYardVersionRange(monitor).getVersions();
+        Collections.sort(_availableVersions, new Comparator<Version>() {
+            @Override
+            public int compare(Version o1, Version o2) {
+                // list the highest version first
+                return -o1.compareTo(o2);
+            }
+        });
+        _runtimeVersionsList.setInput(_availableVersions);
+    }
+
+    private void populateComponentsTable() {
+        _componentsTable.setInput(SwitchYardComponentExtensionManager.instance().getComponentExtensions());
+    }
+
+    private void selectAllComponents() {
+        _componentsTable.setAllChecked(true);
+    }
+
+    private void deselectAllComponents() {
+        _componentsTable.setAllChecked(false);
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/SwitchYardProject.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/SwitchYardProject.java
@@ -1,0 +1,456 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.common.impl;
+
+import static org.switchyard.tools.ui.M2EUtils.CONFIGURATION_ELEMENT;
+import static org.switchyard.tools.ui.M2EUtils.CONFIGURE_GOAL;
+import static org.switchyard.tools.ui.M2EUtils.PARAM_ELEMENT;
+import static org.switchyard.tools.ui.M2EUtils.SCANNER_CLASS_NAMES_ELEMENT;
+import static org.switchyard.tools.ui.M2EUtils.SWITCHYARD_CORE_GROUP_ID;
+import static org.switchyard.tools.ui.M2EUtils.SWITCHYARD_PLUGIN_KEY;
+import static org.switchyard.tools.ui.M2EUtils.SWITCHYARD_VERSION;
+import static org.switchyard.tools.ui.M2EUtils.UNKNOWN_VERSION_STRING;
+import static org.switchyard.tools.ui.M2EUtils.createSwitchYardPlugin;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.common.ISwitchYardComponentExtension;
+import org.switchyard.tools.ui.common.ISwitchYardProject;
+import org.switchyard.tools.ui.common.ISwitchYardProjectWorkingCopy;
+import org.switchyard.tools.ui.common.SwitchYardComponentExtensionManager;
+
+/**
+ * SwitchYardProject
+ * 
+ * <p/>
+ * Implementation of ISwitchYardProject.
+ * 
+ * @author Rob Cernich
+ */
+@SuppressWarnings("restriction")
+public class SwitchYardProject implements ISwitchYardProject {
+
+    private IProject _project;
+    private volatile MavenProject _mavenProject;
+    private volatile String _version;
+    private volatile String _versionPropertyKey;
+    private volatile String _rawVersionString;
+    private volatile boolean _usingDependencyManagement;
+    private volatile Set<ISwitchYardComponentExtension> _components;
+    private volatile SwitchYardConfigurePlugin _plugin;
+    private Set<SwitchYardProjectWorkingCopy> _workingCopies = new HashSet<SwitchYardProjectWorkingCopy>();
+
+    /**
+     * Create a new SwitchYardProject.
+     * 
+     * @param project the underlying Eclipse project.
+     */
+    public SwitchYardProject(IProject project) {
+        _project = project;
+        IMavenProjectFacade mavenProjectFacade = MavenPlugin.getMavenProjectRegistry().getProject(project);
+        if (mavenProjectFacade != null && !mavenProjectFacade.isStale()) {
+            _mavenProject = mavenProjectFacade.getMavenProject();
+        }
+        init();
+    }
+
+    @Override
+    public IProject getProject() {
+        return _project;
+    }
+
+    @Override
+    public MavenProject getMavenProject() {
+        return _mavenProject;
+    }
+
+    @Override
+    public String getVersion() {
+        return _version;
+    }
+
+    @Override
+    public String getVersionPropertyKey() {
+        return _versionPropertyKey;
+    }
+
+    @Override
+    public Set<ISwitchYardComponentExtension> getComponents() {
+        return Collections.unmodifiableSet(_components);
+    }
+
+    @Override
+    public boolean isUsingDependencyManagement() {
+        return _usingDependencyManagement;
+    }
+
+    @Override
+    public String getRawVersionString() {
+        return _rawVersionString;
+    }
+
+    @Override
+    public boolean needsLoading() {
+        return _mavenProject == null;
+    }
+
+    @Override
+    public synchronized void load(IProgressMonitor monitor) {
+        monitor.beginTask("Loading Maven configuration for SwitchYard project.", 100);
+        monitor.worked(10);
+        SubProgressMonitor subMonitor = new SubProgressMonitor(monitor, 75);
+        try {
+            // reload the project
+            _mavenProject = MavenPlugin.getMaven().readProject(
+                    _project.getFile(IMavenConstants.POM_FILE_NAME).getLocation().toFile(), subMonitor);
+            subMonitor.done();
+        } catch (CoreException e) {
+            Activator.getDefault().getLog().log(e.getStatus());
+        }
+        subMonitor.done();
+        init();
+
+        for (SwitchYardProjectWorkingCopy workingCopy : _workingCopies) {
+            workingCopy.reloaded();
+        }
+        monitor.done();
+    }
+
+    @Override
+    public synchronized ISwitchYardProjectWorkingCopy createWorkingCopy() {
+        SwitchYardProjectWorkingCopy workingCopy = new SwitchYardProjectWorkingCopy(this);
+        _workingCopies.add(workingCopy);
+        return workingCopy;
+    }
+
+    protected SwitchYardConfigurePlugin getPlugin() {
+        return _plugin;
+    }
+
+    /* package */
+    synchronized void disposed(SwitchYardProjectWorkingCopy workingCopy) {
+        _workingCopies.remove(workingCopy);
+    }
+
+    private synchronized void init() {
+        _version = null;
+        _versionPropertyKey = SWITCHYARD_VERSION;
+        _components = Collections.emptySet();
+        _rawVersionString = null;
+        _usingDependencyManagement = false;
+        _plugin = new SwitchYardConfigurePlugin();
+
+        if (_mavenProject == null) {
+            return;
+        }
+
+        _version = readSwitchYardVersion();
+        _versionPropertyKey = readSwitchYardVersionPropertyKey();
+        _rawVersionString = readRawVersionString();
+        if (_rawVersionString == null) {
+            _usingDependencyManagement = true;
+        } else if (_rawVersionString == UNKNOWN_VERSION_STRING) {
+            if (_version == null) {
+                _usingDependencyManagement = false;
+                _rawVersionString = "${" + _versionPropertyKey + "}";
+            } else {
+                _usingDependencyManagement = true;
+                _rawVersionString = null;
+            }
+        }
+        _components = readComponents();
+    }
+
+    private String readSwitchYardVersion() {
+        for (Dependency dependency : _mavenProject.getDependencies()) {
+            if (SWITCHYARD_CORE_GROUP_ID.equals(dependency.getGroupId()) && dependency.getVersion() != null) {
+                return dependency.getVersion();
+            }
+        }
+        Plugin switchYardPlugin = getSwitchYardPlugin();
+        if (switchYardPlugin == null) {
+            return null;
+        }
+        return switchYardPlugin.getVersion();
+    }
+
+    private Plugin getSwitchYardPlugin() {
+        if (_mavenProject == null) {
+            return null;
+        }
+        return _mavenProject.getPlugin(SWITCHYARD_PLUGIN_KEY);
+    }
+
+    private String readRawVersionString() {
+        if (_mavenProject.getDependencyManagement() != null) {
+            for (Dependency dependency : _mavenProject.getDependencyManagement().getDependencies()) {
+                if (SWITCHYARD_CORE_GROUP_ID.equals(dependency.getGroupId())) {
+                    // using dependency management
+                    return null;
+                }
+            }
+        }
+        for (Dependency dependency : _mavenProject.getOriginalModel().getDependencies()) {
+            if (SWITCHYARD_CORE_GROUP_ID.equals(dependency.getGroupId())) {
+                return dependency.getVersion();
+            }
+        }
+        return UNKNOWN_VERSION_STRING;
+    }
+
+    private Set<ISwitchYardComponentExtension> readComponents() {
+        Collection<ISwitchYardComponentExtension> extensions = SwitchYardComponentExtensionManager.instance()
+                .getComponentExtensions();
+        Set<ISwitchYardComponentExtension> retVal = new LinkedHashSet<ISwitchYardComponentExtension>(extensions.size());
+        Set<String> dependencyKeys = createDependencyKeySet(_mavenProject.getDependencies());
+        Set<String> pluginScanners = new SwitchYardConfigurePlugin().getScannerClasses();
+        ExtensionsLoop: for (ISwitchYardComponentExtension extension : extensions) {
+            if (extension.getScannerClassName() != null && !pluginScanners.contains(extension.getScannerClassName())) {
+                continue ExtensionsLoop;
+            }
+            for (Dependency dependency : extension.getDependencies()) {
+                if (!dependencyKeys.contains(dependency.getManagementKey())) {
+                    continue ExtensionsLoop;
+                }
+            }
+            retVal.add(extension);
+        }
+        return retVal;
+    }
+
+    private String readSwitchYardVersionPropertyKey() {
+        boolean foundComponent = false;
+        for (Dependency dependency : _mavenProject.getOriginalModel().getDependencies()) {
+            if (SWITCHYARD_CORE_GROUP_ID.equals(dependency.getGroupId())) {
+                String dependencyVersion = dependency.getVersion();
+                if (dependencyVersion == null || !dependencyVersion.startsWith("${") || dependencyVersion.length() < 4) {
+                    foundComponent = true;
+                    continue;
+                }
+                return dependencyVersion.substring(2, dependencyVersion.length() - 1);
+            }
+        }
+        if (_mavenProject.getOriginalModel().getDependencyManagement() != null) {
+            for (Dependency dependency : _mavenProject.getOriginalModel().getDependencyManagement().getDependencies()) {
+                if (SWITCHYARD_CORE_GROUP_ID.equals(dependency.getGroupId())) {
+                    String dependencyVersion = dependency.getVersion();
+                    if (dependencyVersion == null || !dependencyVersion.startsWith("${")
+                            || dependencyVersion.length() < 4) {
+                        foundComponent = true;
+                        continue;
+                    }
+                    return dependencyVersion.substring(2, dependencyVersion.length() - 1);
+                }
+            }
+        }
+        Plugin switchYardPlugin = getPlugin().getOriginalPlugin();
+        if (switchYardPlugin == null) {
+            return foundComponent ? null : SWITCHYARD_VERSION;
+        }
+        String pluginVersion = switchYardPlugin.getVersion();
+        if (pluginVersion == null || !pluginVersion.startsWith("${") || pluginVersion.length() < 4) {
+            return null;
+        }
+        return pluginVersion.substring(2, pluginVersion.length() - 1);
+    }
+
+    private Set<String> createDependencyKeySet(Collection<Dependency> dependencies) {
+        Set<String> dependencyKeySet = new HashSet<String>();
+        for (Dependency dependency : dependencies) {
+            dependencyKeySet.add(dependency.getManagementKey());
+        }
+        return dependencyKeySet;
+    }
+
+    protected final class SwitchYardConfigurePlugin {
+
+        private Plugin _switchYardPlugin;
+        private Set<String> _scannerClasses;
+
+        private SwitchYardConfigurePlugin() {
+            _switchYardPlugin = getSwitchYardPlugin();
+            if (_switchYardPlugin == null) {
+                _scannerClasses = Collections.emptySet();
+                return;
+            }
+
+            _scannerClasses = new HashSet<String>();
+            Object configuration = _switchYardPlugin.getConfiguration();
+            if (configuration instanceof Xpp3Dom) {
+                _scannerClasses.addAll(parseConfiguration((Xpp3Dom) configuration));
+            }
+            for (PluginExecution execution : _switchYardPlugin.getExecutions()) {
+                if (execution.getGoals().contains(CONFIGURE_GOAL)) {
+                    configuration = execution.getConfiguration();
+                    if (configuration instanceof Xpp3Dom) {
+                        _scannerClasses.addAll(parseConfiguration((Xpp3Dom) configuration));
+                    }
+                }
+            }
+        }
+
+        public Set<String> getScannerClasses() {
+            return _scannerClasses;
+        }
+
+        public Plugin getPlugin() {
+            return _switchYardPlugin;
+        }
+
+        public Plugin getOriginalPlugin() {
+            if (_mavenProject == null) {
+                return null;
+            }
+            return _mavenProject.getOriginalModel().getBuild().getPluginsAsMap().get(SWITCHYARD_PLUGIN_KEY);
+        }
+
+        public boolean updateScannerClasses(Set<String> added, Set<String> removed) {
+            added.removeAll(_scannerClasses);
+            removed.retainAll(_scannerClasses);
+            if (added.isEmpty() && removed.isEmpty()) {
+                return false;
+            }
+            Plugin plugin = getOriginalPlugin();
+            if (plugin == null) {
+                if (added.isEmpty()) {
+                    // can't remove anything and we're not adding anything, so
+                    // no changes
+                    return false;
+                }
+                // see if we need to create an execution
+                boolean createExecution = true;
+                if (_switchYardPlugin != null) {
+                    for (PluginExecution execution : _switchYardPlugin.getExecutions()) {
+                        if (execution.getGoals().contains(CONFIGURE_GOAL)) {
+                            createExecution = false;
+                            break;
+                        }
+                    }
+                }
+                installSwitchYardPlugin(createExecution, added);
+            } else {
+                Xpp3Dom configuration = null;
+                Object pluginConfiguration = plugin.getConfiguration();
+                if (pluginConfiguration instanceof Xpp3Dom) {
+                    configuration = (Xpp3Dom) pluginConfiguration;
+                    Xpp3Dom[] children = configuration.getChildren(SCANNER_CLASS_NAMES_ELEMENT);
+                    if (children != null && children.length > 0) {
+                        removeScanners(children[0], removed);
+                        addScanners(children[0], added);
+                        return true;
+                    }
+                }
+
+                for (PluginExecution execution : plugin.getExecutions()) {
+                    if (execution.getGoals().contains(CONFIGURE_GOAL)) {
+                        Object test = execution.getConfiguration();
+                        if (test instanceof Xpp3Dom) {
+                            Xpp3Dom[] children = ((Xpp3Dom) test).getChildren(SCANNER_CLASS_NAMES_ELEMENT);
+                            if (children != null && children.length > 0) {
+                                removeScanners(children[0], removed);
+                                addScanners(children[0], added);
+                                // we'll only process the first execution. not
+                                // sure how to handle multiple executions. i'm
+                                // assuming we wouldn't want them to all have
+                                // the same configuration.
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                // no scanners config
+                if (configuration == null) {
+                    configuration = new Xpp3Dom(CONFIGURATION_ELEMENT);
+                    plugin.setConfiguration(configuration);
+                }
+                Xpp3Dom scannerElement;
+                Xpp3Dom[] children = configuration.getChildren(SCANNER_CLASS_NAMES_ELEMENT);
+                if (children == null || children.length == 0) {
+                    scannerElement = new Xpp3Dom(SCANNER_CLASS_NAMES_ELEMENT);
+                    configuration.addChild(scannerElement);
+                } else {
+                    scannerElement = children[0];
+                }
+                addScanners(scannerElement, added);
+            }
+            return true;
+        }
+
+        private void removeScanners(Xpp3Dom scannerElement, Set<String> removed) {
+            for (int index = 0; index < scannerElement.getChildCount(); ++index) {
+                Xpp3Dom child = scannerElement.getChild(index);
+                if (PARAM_ELEMENT.equals(child.getName()) && removed.contains(child.getValue())) {
+                    scannerElement.removeChild(index);
+                    --index;
+                }
+            }
+        }
+
+        private void addScanners(Xpp3Dom scannerElement, Set<String> added) {
+            for (String scanner : added) {
+                Xpp3Dom paramElement = new Xpp3Dom(PARAM_ELEMENT);
+                paramElement.setValue(scanner);
+                scannerElement.addChild(paramElement);
+            }
+        }
+
+        private Set<String> parseConfiguration(Xpp3Dom configuration) {
+            Xpp3Dom scannerClassNames = configuration.getChild(SCANNER_CLASS_NAMES_ELEMENT);
+            if (scannerClassNames == null) {
+                return Collections.emptySet();
+            }
+            Set<String> scannerClasses = new HashSet<String>();
+            for (Xpp3Dom param : scannerClassNames.getChildren(PARAM_ELEMENT)) {
+                _scannerClasses.add(param.getValue());
+            }
+            return scannerClasses;
+        }
+
+        private void installSwitchYardPlugin(boolean createExecution, Set<String> scanners) {
+            Model model = _mavenProject.getOriginalModel();
+            Build build = model.getBuild();
+            if (build == null) {
+                build = new Build();
+                model.setBuild(build);
+            }
+            build.addPlugin(createSwitchYardPlugin(_rawVersionString, createExecution, scanners));
+        }
+
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/SwitchYardProjectWorkingCopy.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/SwitchYardProjectWorkingCopy.java
@@ -1,0 +1,395 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.common.impl;
+
+import static org.switchyard.tools.ui.M2EUtils.JBOSS_PUBLIC_REPOSITORY_DEFAULT_ID;
+import static org.switchyard.tools.ui.M2EUtils.JBOSS_PUBLIC_REPOSITORY_URL;
+import static org.switchyard.tools.ui.M2EUtils.createJBossPublicRepository;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Repository;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.project.MavenUpdateRequest;
+import org.eclipse.m2e.core.ui.internal.UpdateConfigurationJob;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.common.ISwitchYardComponentExtension;
+import org.switchyard.tools.ui.common.ISwitchYardProjectWorkingCopy;
+import org.switchyard.tools.ui.common.SwitchYardComponentExtensionManager;
+
+/**
+ * SwitchYardProjectWorkingCopy
+ * 
+ * <p/>
+ * Implements {@link ISwitchYardProjectWorkingCopy}.
+ * 
+ * @author Rob Cernich
+ */
+@SuppressWarnings("restriction")
+public class SwitchYardProjectWorkingCopy implements ISwitchYardProjectWorkingCopy {
+
+    private final SwitchYardProject _switchYardProject;
+    private MavenProject _mavenProject;
+    private Map<String, ISwitchYardComponentExtension> _addedComponents = new LinkedHashMap<String, ISwitchYardComponentExtension>();
+    private Map<String, ISwitchYardComponentExtension> _removedComponents = new LinkedHashMap<String, ISwitchYardComponentExtension>();
+    private Set<ISwitchYardComponentExtension> _mergedComponents = new LinkedHashSet<ISwitchYardComponentExtension>();
+    private volatile String _newVersion;
+    private boolean _configurationChanged;
+
+    /**
+     * Create a new SwitchYardProjectWorkingCopy.
+     * 
+     * @param switchYardProject the original SwitchYard project.
+     */
+    public SwitchYardProjectWorkingCopy(SwitchYardProject switchYardProject) {
+        _switchYardProject = switchYardProject;
+        _mavenProject = _switchYardProject.getMavenProject();
+        _mergedComponents.addAll(_switchYardProject.getComponents());
+    }
+
+    @Override
+    public IProject getProject() {
+        return _switchYardProject.getProject();
+    }
+
+    @Override
+    public MavenProject getMavenProject() {
+        return _switchYardProject.getMavenProject();
+    }
+
+    @Override
+    public String getVersion() {
+        return _newVersion == null ? _switchYardProject.getVersion() : _newVersion;
+    }
+
+    @Override
+    public String getVersionPropertyKey() {
+        return _switchYardProject.getVersionPropertyKey();
+    }
+
+    @Override
+    public Set<ISwitchYardComponentExtension> getComponents() {
+        return _mergedComponents;
+    }
+
+    @Override
+    public boolean isUsingDependencyManagement() {
+        return _switchYardProject.isUsingDependencyManagement();
+    }
+
+    @Override
+    public String getRawVersionString() {
+        return _switchYardProject.getRawVersionString();
+    }
+
+    @Override
+    public boolean needsLoading() {
+        return _switchYardProject.needsLoading();
+    }
+
+    @Override
+    public void load(IProgressMonitor monitor) {
+        _switchYardProject.load(monitor);
+    }
+
+    /* package */
+    void reloaded() {
+        synchronized (_switchYardProject) {
+            _mavenProject = _switchYardProject.getMavenProject();
+            _mergedComponents.clear();
+            _mergedComponents.addAll(_switchYardProject.getComponents());
+            if (_newVersion != null && _newVersion.equals(_switchYardProject.getVersion())) {
+                _newVersion = null;
+            }
+            for (Iterator<ISwitchYardComponentExtension> it = _removedComponents.values().iterator(); it.hasNext();) {
+                ISwitchYardComponentExtension component = it.next();
+                if (!_mergedComponents.contains(component)) {
+                    it.remove();
+                }
+            }
+            for (Iterator<ISwitchYardComponentExtension> it = _addedComponents.values().iterator(); it.hasNext();) {
+                ISwitchYardComponentExtension component = it.next();
+                if (_switchYardProject.getComponents().contains(component)) {
+                    it.remove();
+                }
+                _mergedComponents.add(component);
+            }
+        }
+    }
+
+    @Override
+    public ISwitchYardProjectWorkingCopy createWorkingCopy() {
+        return _switchYardProject.createWorkingCopy();
+    }
+
+    @Override
+    public void setRuntimeVersion(String version) {
+        if (version == null) {
+            _newVersion = null;
+            return;
+        }
+        _newVersion = version;
+        if (_newVersion.equals(_switchYardProject.getVersion())) {
+            _newVersion = null;
+        }
+    }
+
+    @Override
+    public void addComponent(ISwitchYardComponentExtension component) {
+        synchronized (_switchYardProject) {
+            _removedComponents.remove(component.getId());
+            _mergedComponents.add(component);
+            if (_addedComponents.containsKey(component.getId())
+                    || _switchYardProject.getComponents().contains(component)) {
+                // already in added list or was there originally
+                return;
+            }
+            _addedComponents.put(component.getId(), component);
+        }
+    }
+
+    @Override
+    public void addComponents(Collection<ISwitchYardComponentExtension> components) {
+        synchronized (_switchYardProject) {
+            for (ISwitchYardComponentExtension component : components) {
+                addComponent(component);
+            }
+        }
+    }
+
+    @Override
+    public void removeComponent(ISwitchYardComponentExtension component) {
+        synchronized (_switchYardProject) {
+            _addedComponents.remove(component.getId());
+            _mergedComponents.remove(component);
+            if (_removedComponents.containsKey(component.getId())
+                    || !_switchYardProject.getComponents().contains(component)) {
+                // already in removed list or wasn't there originally
+                return;
+            }
+            _removedComponents.put(component.getId(), component);
+        }
+    }
+
+    @Override
+    public void removeComponents(Collection<ISwitchYardComponentExtension> components) {
+        synchronized (_switchYardProject) {
+            for (ISwitchYardComponentExtension component : components) {
+                removeComponent(component);
+            }
+        }
+    }
+
+    @Override
+    public boolean isModified() {
+        synchronized (_switchYardProject) {
+            return _newVersion != null || !_removedComponents.isEmpty() || !_addedComponents.isEmpty();
+        }
+    }
+
+    @Override
+    public void commit(IProgressMonitor monitor) throws CoreException {
+        synchronized (_switchYardProject) {
+
+            _configurationChanged = false;
+
+            if (!isModified()) {
+                monitor.done();
+                return;
+            }
+            monitor.beginTask("Updating project pom.", 300);
+            IProgressMonitor subMonitor = new SubProgressMonitor(monitor, 100,
+                    SubProgressMonitor.PREPEND_MAIN_LABEL_TO_SUBTASK);
+            if (processUpdates(subMonitor)) {
+                subMonitor.done();
+
+                // write out the changes
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                MavenPlugin.getMaven().writeModel(getMavenProject().getOriginalModel(), baos);
+
+                subMonitor = new SubProgressMonitor(monitor, 100, SubProgressMonitor.PREPEND_MAIN_LABEL_TO_SUBTASK);
+                getProject().getFile(IMavenConstants.POM_FILE_NAME).setContents(
+                        new ByteArrayInputStream(baos.toByteArray()), true, true, subMonitor);
+                subMonitor.done();
+
+                // make sure the project gets refreshed
+                MavenPlugin.getMavenProjectRegistry().refresh(
+                        new MavenUpdateRequest(getProject(), MavenPlugin.getMavenConfiguration().isOffline(), false));
+
+                // update ourselves
+                if (_configurationChanged) {
+                    // need to update maven project configuration; refreshes the
+                    // project too.
+                    new UpdateConfigurationJob(new IProject[] {getProject() }).schedule();
+                } else {
+                    MavenPlugin.getMavenProjectRegistry()
+                            .refresh(
+                                    new MavenUpdateRequest(getProject(), MavenPlugin.getMavenConfiguration()
+                                            .isOffline(), false));
+                }
+
+                subMonitor = new SubProgressMonitor(monitor, 100, SubProgressMonitor.PREPEND_MAIN_LABEL_TO_SUBTASK);
+                load(subMonitor);
+
+            }
+            subMonitor.done();
+            monitor.done();
+        }
+    }
+
+    @Override
+    public void revert() {
+        synchronized (_switchYardProject) {
+            _newVersion = null;
+            _addedComponents.clear();
+            _removedComponents.clear();
+            _mergedComponents.clear();
+            _mergedComponents.addAll(_switchYardProject.getComponents());
+        }
+    }
+
+    @Override
+    public void dispose() {
+        _switchYardProject.disposed(this);
+    }
+
+    private boolean processUpdates(IProgressMonitor monitor) throws CoreException {
+        boolean modelUpdated = false;
+
+        monitor.beginTask("Processing SwitchYard settings changes.", 50);
+
+        if (_mavenProject != _switchYardProject.getMavenProject()) {
+            throw new CoreException(
+                    new Status(Status.ERROR, Activator.PLUGIN_ID,
+                            "ISwitchYardProjectWorkingCopy is out of sync with ISwitchYardProject.  Updates cannot be processed."));
+        }
+
+        Model model = _switchYardProject.getMavenProject().getOriginalModel();
+
+        monitor.subTask("Validating switchyard.version property.");
+        final String switchYardVersionPropertyKey = getVersionPropertyKey();
+        final String currentSwitchYardVersion = _switchYardProject.getVersion();
+        if (switchYardVersionPropertyKey != null) {
+            if (_newVersion != null) {
+                model.addProperty(switchYardVersionPropertyKey, _newVersion);
+                modelUpdated = true;
+            } else if (currentSwitchYardVersion == null) {
+                model.addProperty(switchYardVersionPropertyKey, "");
+                modelUpdated = true;
+            }
+        }
+        monitor.worked(10);
+
+        monitor.subTask("Validating component dependencies.");
+
+        if (_removedComponents.size() > 0) {
+            // there's got to be a better way....
+            for (ISwitchYardComponentExtension component : _removedComponents.values()) {
+                for (Dependency dependency : component.getDependencies()) {
+                    for (Iterator<Dependency> it = model.getDependencies().iterator(); it.hasNext();) {
+                        if (it.next().getManagementKey().equals(dependency.getManagementKey())) {
+                            it.remove();
+                            modelUpdated = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        monitor.worked(10);
+
+        // make sure the runtime component is always present
+        addComponent(SwitchYardComponentExtensionManager.instance().getRuntimeComponentExtension());
+        if (_addedComponents.size() > 0) {
+            final String versionString = getRawVersionString();
+            for (ISwitchYardComponentExtension component : _addedComponents.values()) {
+                for (Dependency dependency : component.getDependencies()) {
+                    dependency = dependency.clone();
+                    dependency.setVersion(versionString);
+                    model.getDependencies().add(dependency);
+                    modelUpdated = true;
+                }
+            }
+        }
+        monitor.worked(10);
+
+        monitor.subTask("Validating SwitchYard plugin.");
+        if (_switchYardProject.getPlugin().updateScannerClasses(collectScanners(_addedComponents.values()),
+                collectScanners(_removedComponents.values()))) {
+            modelUpdated = true;
+            _configurationChanged = true;
+        }
+        monitor.worked(10);
+
+        monitor.subTask("Validating repository settings.");
+        boolean foundRepo = false;
+        for (Repository repo : getMavenProject().getRepositories()) {
+            if (JBOSS_PUBLIC_REPOSITORY_URL.equals(repo.getUrl())) {
+                foundRepo = true;
+                break;
+            }
+        }
+        if (!foundRepo) {
+            model.addRepository(createJBossPublicRepository(JBOSS_PUBLIC_REPOSITORY_DEFAULT_ID));
+            modelUpdated = true;
+        }
+        foundRepo = false;
+        for (Repository repo : getMavenProject().getPluginRepositories()) {
+            if (JBOSS_PUBLIC_REPOSITORY_URL.equals(repo.getUrl())) {
+                foundRepo = true;
+                break;
+            }
+        }
+        if (!foundRepo) {
+            model.addPluginRepository(createJBossPublicRepository(JBOSS_PUBLIC_REPOSITORY_DEFAULT_ID));
+            modelUpdated = true;
+        }
+
+        monitor.done();
+
+        return modelUpdated;
+    }
+
+    private Set<String> collectScanners(Collection<ISwitchYardComponentExtension> components) {
+        Set<String> scanners = new LinkedHashSet<String>();
+        for (ISwitchYardComponentExtension component : components) {
+            String scanner = component.getScannerClassName();
+            if (scanner != null && scanner.length() > 0) {
+                scanners.add(scanner);
+            }
+        }
+        return scanners;
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/ISwitchYardFacetConstants.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/ISwitchYardFacetConstants.java
@@ -18,6 +18,9 @@
  */
 package org.switchyard.tools.ui.facets;
 
+import org.eclipse.wst.common.project.facet.core.IProjectFacet;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+
 /**
  * ISwitchYardFacetConstants
  * 
@@ -34,6 +37,10 @@ public interface ISwitchYardFacetConstants {
     public static final String RUNTIME_PROVIDED = "SwitchYard.RUNTIME_PROVIDED";
     /** Property ID used to indicate the desired SwitchYard runtime version. */
     public static final String RUNTIME_VERSION = "SwitchYard.RUNTIME_VERSION";
+    /** Property ID used to indicate the desired SwitchYard components. */
+    public static final String RUNTIME_COMPONENTS = "SwitchYard.RUNTIME_COMPONENTS";
+    /** Property ID used to indicate the ISwitchYardProject instance. */
+    public static final String SWITCHYARD_PROJECT = "SwitchYard.SWITCHYARD_PROJECT";
 
     /** The ID of the SwitchYard facet. */
     public static final String SWITCHYARD_FACET_ID = "switchyard.core";
@@ -52,4 +59,6 @@ public interface ISwitchYardFacetConstants {
     /** The ID of the JBoss Maven Integration facet. */
     public static final String JBOSS_M2_FACET_ID = "jboss.m2";
 
+    /** The SwitchYard facet. */
+    public static final IProjectFacet SWITCHYARD_FACET = ProjectFacetsManager.getProjectFacet(SWITCHYARD_FACET_ID);
 }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallActionDelegate.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallActionDelegate.java
@@ -18,16 +18,23 @@
  */
 package org.switchyard.tools.ui.facets;
 
-import java.util.Arrays;
+import java.util.Collection;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.wst.common.componentcore.datamodel.properties.IFacetDataModelProperties;
 import org.eclipse.wst.common.frameworks.datamodel.IDataModel;
 import org.eclipse.wst.common.project.facet.core.IDelegate;
+import org.eclipse.wst.common.project.facet.core.IFacetedProjectWorkingCopy;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.sonatype.aether.version.Version;
-import org.switchyard.tools.ui.M2EUtils;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.common.ISwitchYardComponentExtension;
+import org.switchyard.tools.ui.common.ISwitchYardProject;
+import org.switchyard.tools.ui.common.ISwitchYardProjectWorkingCopy;
+import org.switchyard.tools.ui.common.impl.SwitchYardProject;
 import org.switchyard.tools.ui.operations.AbstractSwitchYardProjectOperation;
 
 /**
@@ -40,14 +47,40 @@ import org.switchyard.tools.ui.operations.AbstractSwitchYardProjectOperation;
 public class SwitchYardFacetInstallActionDelegate implements IDelegate {
 
     @Override
+    @SuppressWarnings("unchecked")
     public void execute(final IProject project, IProjectFacetVersion fv, Object config, IProgressMonitor monitor)
             throws CoreException {
-        Object versionObject = config instanceof IDataModel ? ((IDataModel) config)
-                .getProperty(ISwitchYardFacetConstants.RUNTIME_VERSION) : null;
+        IDataModel dataModel = (IDataModel) config;
+
+        // TODO: get selected components
+        ISwitchYardProjectWorkingCopy workingCopy;
+        ISwitchYardProject switchYardProject = (ISwitchYardProject) dataModel
+                .getProperty(ISwitchYardFacetConstants.SWITCHYARD_PROJECT);
+        if (switchYardProject == null) {
+            IFacetedProjectWorkingCopy ifpwc = (IFacetedProjectWorkingCopy) dataModel
+                    .getProperty(IFacetDataModelProperties.FACETED_PROJECT_WORKING_COPY);
+            if (ifpwc != null) {
+                switchYardProject = new SwitchYardProject(ifpwc.getProject());
+            }
+        }
+        if (switchYardProject == null) {
+            throw new CoreException(
+                    new Status(
+                            Status.ERROR,
+                            Activator.PLUGIN_ID,
+                            "Could not resolve SwitchYard project.  SwitchYard facet installation is incomplete.  Project POM has not been updated."));
+        }
+
+        Object versionObject = dataModel.getProperty(ISwitchYardFacetConstants.RUNTIME_VERSION);
         String versionString = versionObject instanceof Version ? ((Version) versionObject).toString() : null;
+
+        workingCopy = switchYardProject.createWorkingCopy();
+        workingCopy.setRuntimeVersion(versionString);
+        workingCopy.addComponents((Collection<ISwitchYardComponentExtension>) dataModel
+                .getProperty(ISwitchYardFacetConstants.RUNTIME_COMPONENTS));
+
         // make sure the sy stuff is in the pom
-        new AbstractSwitchYardProjectOperation(versionString, M2EUtils.DEFAULT_DEPENDENCIES,
-                Arrays.asList(M2EUtils.DEFAULT_SCANNERS), false, "Installing SwitchYard Facet", null) {
+        new AbstractSwitchYardProjectOperation(workingCopy, false, "Installing SwitchYard Facet", null) {
             @Override
             protected void execute(IProgressMonitor monitor) throws CoreException {
                 // nothing extra
@@ -60,5 +93,4 @@ public class SwitchYardFacetInstallActionDelegate implements IDelegate {
 
         }.run(monitor);
     }
-
 }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallConfigFactory.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallConfigFactory.java
@@ -18,16 +18,26 @@
  */
 package org.switchyard.tools.ui.facets;
 
+import static org.switchyard.tools.ui.M2EUtils.resolveSwitchYardVersionRange;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.wst.common.componentcore.datamodel.FacetInstallDataModelProvider;
 import org.eclipse.wst.common.project.facet.core.IFacetedProjectWorkingCopy;
 import org.sonatype.aether.util.version.GenericVersionScheme;
+import org.sonatype.aether.version.InvalidVersionSpecificationException;
 import org.sonatype.aether.version.Version;
 import org.switchyard.tools.ui.Activator;
-import org.switchyard.tools.ui.M2EUtils;
+import org.switchyard.tools.ui.common.ISwitchYardProject;
+import org.switchyard.tools.ui.common.impl.SwitchYardProject;
 
 /**
  * SwitchYardFacetInstallConfigFactory
@@ -39,13 +49,51 @@ import org.switchyard.tools.ui.M2EUtils;
 public class SwitchYardFacetInstallConfigFactory extends FacetInstallDataModelProvider implements
         ISwitchYardFacetConstants {
 
+    private List<Version> _versions;
+    private Version _defaultVersion;
+    private ISwitchYardProject _switchYardProject;
+
     @SuppressWarnings({"rawtypes", "unchecked" })
     @Override
     public Set getPropertyNames() {
         Set names = super.getPropertyNames();
         names.add(RUNTIME_PROVIDED);
         names.add(RUNTIME_VERSION);
+        names.add(RUNTIME_COMPONENTS);
+        names.add(SWITCHYARD_PROJECT);
         return names;
+    }
+
+    private void projectWorkingCopyUpdated(IFacetedProjectWorkingCopy ifpwc) {
+        try {
+            loadDefaults(ifpwc);
+        } catch (Exception e) {
+            e.fillInStackTrace();
+        }
+
+        // the default version
+        for (ListIterator<Version> lit = _versions.listIterator(_versions.size()); lit.hasPrevious();) {
+            Version version = lit.previous();
+            if (_defaultVersion == null) {
+                _defaultVersion = version;
+            }
+            if (!version.toString().endsWith("-SNAPSHOT")) {
+                _defaultVersion = version;
+                break;
+            }
+        }
+        if (_switchYardProject != null) {
+            String versionString = _switchYardProject.getVersion();
+            if (versionString != null && versionString.length() > 0) {
+                try {
+                    getDataModel().setProperty(RUNTIME_VERSION, new GenericVersionScheme().parseVersion(versionString));
+                } catch (InvalidVersionSpecificationException e) {
+                    e.fillInStackTrace();
+                }
+                getDataModel().setProperty(RUNTIME_COMPONENTS, _switchYardProject.getComponents());
+            }
+        }
+        getDataModel().setProperty(SWITCHYARD_PROJECT, _switchYardProject);
     }
 
     @Override
@@ -55,19 +103,11 @@ public class SwitchYardFacetInstallConfigFactory extends FacetInstallDataModelPr
         } else if (RUNTIME_PROVIDED.equals(propertyName)) {
             return true;
         } else if (RUNTIME_VERSION.equals(propertyName)) {
-            IFacetedProjectWorkingCopy ifpwc = (IFacetedProjectWorkingCopy) getProperty(FACETED_PROJECT_WORKING_COPY);
-            if (ifpwc == null || !ifpwc.getProject().exists()) {
-                return null;
-            }
-            String versionString = M2EUtils.getSwitchYardVersion(ifpwc.getProject());
-            if (versionString == null || versionString.length() == 0) {
-                return null;
-            }
-            try {
-                return new GenericVersionScheme().parseVersion(versionString);
-            } catch (Exception e) {
-                return null;
-            }
+            return _defaultVersion;
+        } else if (RUNTIME_COMPONENTS.equals(propertyName)) {
+            return Collections.emptyList();
+        } else if (SWITCHYARD_PROJECT.equals(propertyName)) {
+            return null;
         }
         return super.getDefaultProperty(propertyName);
     }
@@ -78,6 +118,13 @@ public class SwitchYardFacetInstallConfigFactory extends FacetInstallDataModelPr
             return true;
         } else if (RUNTIME_VERSION.equals(propertyName)) {
             return true;
+        } else if (RUNTIME_COMPONENTS.equals(propertyName)) {
+            return true;
+        } else if (SWITCHYARD_PROJECT.equals(propertyName)) {
+            return false;
+        } else if (FACETED_PROJECT_WORKING_COPY.equals(propertyName)) {
+            // initialize defaults, et al.
+            projectWorkingCopyUpdated((IFacetedProjectWorkingCopy) propertyValue);
         }
         return super.propertySet(propertyName, propertyValue);
     }
@@ -92,8 +139,30 @@ public class SwitchYardFacetInstallConfigFactory extends FacetInstallDataModelPr
                 return Status.OK_STATUS;
             }
             return new Status(Status.ERROR, Activator.PLUGIN_ID, "Must specify SwitchYard runtime version.");
+        } else if (RUNTIME_COMPONENTS.equals(name)) {
+            return Status.OK_STATUS;
         }
         return super.validate(name);
+    }
+
+    private void loadDefaults(IFacetedProjectWorkingCopy ifpwc) throws InvocationTargetException, InterruptedException {
+        if (ifpwc != null && ifpwc.getProject() != null && ifpwc.getProject().exists()) {
+            _switchYardProject = new SwitchYardProject(ifpwc.getProject());
+        }
+        if (_switchYardProject != null && _switchYardProject.needsLoading()) {
+            _switchYardProject.load(new NullProgressMonitor());
+            try {
+                _versions = resolveSwitchYardVersionRange(new NullProgressMonitor()).getVersions();
+            } catch (CoreException e) {
+                _versions = Collections.emptyList();
+            }
+        } else {
+            try {
+                _versions = resolveSwitchYardVersionRange(new NullProgressMonitor()).getVersions();
+            } catch (CoreException e) {
+                _versions = Collections.emptyList();
+            }
+        }
     }
 
 }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateBeanServiceOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateBeanServiceOperation.java
@@ -18,15 +18,9 @@
  */
 package org.switchyard.tools.ui.operations;
 
-import static org.switchyard.tools.ui.M2EUtils.DEFAULT_DEPENDENCIES;
-import static org.switchyard.tools.ui.M2EUtils.createSwitchYardDependency;
-
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
-import org.apache.maven.model.Dependency;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
@@ -34,6 +28,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubProgressMonitor;
 import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.common.ISwitchYardComponentExtension;
+import org.switchyard.tools.ui.common.SwitchYardComponentExtensionManager;
 import org.switchyard.tools.ui.wizards.NewBeanServiceClassWizardPage;
 import org.switchyard.tools.ui.wizards.NewServiceTestClassWizardPage;
 
@@ -46,8 +42,7 @@ import org.switchyard.tools.ui.wizards.NewServiceTestClassWizardPage;
  */
 public class CreateBeanServiceOperation extends AbstractSwitchYardProjectOperation {
 
-    private static final Collection<String> SCANNERS;
-    private static final Collection<Dependency> DEPENDENCIES;
+    private static final Collection<ISwitchYardComponentExtension> REQUIRED_COMPONENTS;
     private NewBeanServiceClassWizardPage _serviceClassPage;
     private NewServiceTestClassWizardPage _serviceTestClassPage;
 
@@ -60,7 +55,7 @@ public class CreateBeanServiceOperation extends AbstractSwitchYardProjectOperati
      */
     public CreateBeanServiceOperation(NewBeanServiceClassWizardPage serviceClassPage,
             NewServiceTestClassWizardPage serviceTestClassPage, IAdaptable uiInfo) {
-        super(null, DEPENDENCIES, SCANNERS, true, "Creating new SwitchYard bean service.", uiInfo);
+        super(null, REQUIRED_COMPONENTS, true, "Creating new SwitchYard bean service.", uiInfo);
         _serviceClassPage = serviceClassPage;
         _serviceTestClassPage = serviceTestClassPage;
     }
@@ -108,10 +103,17 @@ public class CreateBeanServiceOperation extends AbstractSwitchYardProjectOperati
     }
 
     static {
-        List<Dependency> dependencies = new ArrayList<Dependency>();
-        dependencies.addAll(DEFAULT_DEPENDENCIES);
-        dependencies.add(createSwitchYardDependency("org.switchyard.components", "switchyard-component-bean"));
-        DEPENDENCIES = Collections.unmodifiableCollection(dependencies);
-        SCANNERS = Collections.singletonList("org.switchyard.component.bean.config.model.BeanSwitchYardScanner");
+        ISwitchYardComponentExtension found = null;
+        for (ISwitchYardComponentExtension extension : SwitchYardComponentExtensionManager.instance().getComponentExtensions()) {
+            if ("org.switchyard.components:switchyard-component-bean".equals(extension.getId())) {
+                found = extension;
+                break;
+            }
+        }
+        if (found == null) {
+            REQUIRED_COMPONENTS = Collections.emptySet();
+        } else {
+            REQUIRED_COMPONENTS = Collections.singleton(found);
+        }
     }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateServiceTestOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateServiceTestOperation.java
@@ -18,8 +18,6 @@
  */
 package org.switchyard.tools.ui.operations;
 
-import static org.switchyard.tools.ui.M2EUtils.DEFAULT_DEPENDENCIES;
-
 import java.util.Collections;
 
 import org.eclipse.core.resources.IProject;
@@ -29,6 +27,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubProgressMonitor;
 import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.common.SwitchYardComponentExtensionManager;
 import org.switchyard.tools.ui.wizards.NewServiceTestClassWizardPage;
 
 /**
@@ -49,8 +48,9 @@ public class CreateServiceTestOperation extends AbstractSwitchYardProjectOperati
      * @param uiInfo adaptable for UI Shell, may be null.
      */
     public CreateServiceTestOperation(NewServiceTestClassWizardPage serviceTestClassPage, IAdaptable uiInfo) {
-        super(null, DEFAULT_DEPENDENCIES, Collections.<String> emptySet(), false, "Creating new SwitchYard bean service.",
-                uiInfo);
+        super(null, Collections
+                .singleton(SwitchYardComponentExtensionManager.instance().getRuntimeComponentExtension()), false,
+                "Creating new SwitchYard service test.", uiInfo);
         _serviceTestClassPage = serviceTestClassPage;
     }
 

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/properties/SwitchYardSettingsPropertyPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/properties/SwitchYardSettingsPropertyPage.java
@@ -1,0 +1,163 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.properties;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.viewers.CheckStateChangedEvent;
+import org.eclipse.jface.viewers.ICheckStateListener;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.BusyIndicator;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.IWorkbenchPropertyPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.PropertyPage;
+import org.sonatype.aether.util.version.GenericVersionScheme;
+import org.sonatype.aether.version.InvalidVersionSpecificationException;
+import org.sonatype.aether.version.Version;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.common.ILayoutUtilities;
+import org.switchyard.tools.ui.common.ISwitchYardComponentExtension;
+import org.switchyard.tools.ui.common.ISwitchYardProjectWorkingCopy;
+import org.switchyard.tools.ui.common.SwitchYardSettingsGroup;
+import org.switchyard.tools.ui.common.impl.SwitchYardProject;
+import org.switchyard.tools.ui.operations.UpdateProjectPomOperation;
+
+/**
+ * SwitchYardSettingsPropertyPage
+ * 
+ * <p/>
+ * Property page implementation for SwitchYard settings.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardSettingsPropertyPage extends PropertyPage implements IWorkbenchPropertyPage, ILayoutUtilities {
+
+    private SwitchYardSettingsGroup _settingsGroup;
+    private ISwitchYardProjectWorkingCopy _switchYardProject;
+
+    /**
+     * Create a new SwitchYardSettingsPropertyPage.
+     */
+    public SwitchYardSettingsPropertyPage() {
+        super();
+        noDefaultAndApplyButton();
+    }
+
+    @Override
+    protected Control createContents(Composite parent) {
+        Composite content = new Composite(parent, SWT.NONE);
+        content.setLayout(new GridLayout());
+
+        _settingsGroup = new SwitchYardSettingsGroup(content, this, PlatformUI.getWorkbench().getProgressService());
+
+        initControls();
+
+        return content;
+    }
+
+    @Override
+    public boolean performOk() {
+        BusyIndicator.showWhile(getShell().getDisplay(), new Runnable() {
+            public void run() {
+                try {
+                    new UpdateProjectPomOperation(_switchYardProject).run(new NullProgressMonitor());
+                } catch (CoreException e) {
+                    Activator.getDefault().getLog().log(e.getStatus());
+                }
+            }
+        });
+        return true;
+    }
+
+    private void initControls() {
+        _switchYardProject = new SwitchYardProject(getProject()).createWorkingCopy();
+        if (_switchYardProject.needsLoading()) {
+            BusyIndicator.showWhile(getShell().getDisplay(), new Runnable() {
+                @Override
+                public void run() {
+                    _switchYardProject.load(new NullProgressMonitor());
+                }
+            });
+        }
+        initRuntimeVersion();
+        initComponentsTable();
+    }
+
+    private void initRuntimeVersion() {
+        Version version = null;
+        String versionString = _switchYardProject.getVersion();
+        if (versionString != null && versionString.length() > 0) {
+            try {
+                version = new GenericVersionScheme().parseVersion(versionString);
+            } catch (InvalidVersionSpecificationException e) {
+                e.fillInStackTrace();
+            }
+        }
+        if (version != null) {
+            _settingsGroup.getRuntimeVersionsList().setSelection(new StructuredSelection(version), true);
+        }
+        _settingsGroup.getRuntimeVersionsList().getControl()
+                .setEnabled(!_switchYardProject.isUsingDependencyManagement());
+        _settingsGroup.getRuntimeVersionsList().addSelectionChangedListener(new ISelectionChangedListener() {
+            @Override
+            public void selectionChanged(SelectionChangedEvent event) {
+                ISelection selection = event.getSelection();
+                if (selection == null || selection.isEmpty() || !(selection instanceof IStructuredSelection)) {
+                    return;
+                }
+                _switchYardProject.setRuntimeVersion(((IStructuredSelection) selection).getFirstElement().toString());
+            }
+        });
+    }
+
+    private void initComponentsTable() {
+        _settingsGroup.getComponentsTable().setCheckedElements(_switchYardProject.getComponents().toArray());
+        _settingsGroup.getComponentsTable().addCheckStateListener(new ICheckStateListener() {
+            @Override
+            public void checkStateChanged(CheckStateChangedEvent event) {
+                if (event.getChecked()) {
+                    _switchYardProject.addComponent((ISwitchYardComponentExtension) event.getElement());
+                } else {
+                    _switchYardProject.removeComponent((ISwitchYardComponentExtension) event.getElement());
+                }
+            }
+        });
+    }
+
+    private IProject getProject() {
+        return (IProject) getElement().getAdapter(IProject.class);
+    }
+
+    @Override
+    public GridData setButtonLayoutData(Button button) {
+        return super.setButtonLayoutData(button);
+    }
+
+}

--- a/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/CreateSwitchYardProjectTest.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/CreateSwitchYardProjectTest.java
@@ -39,10 +39,11 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
-import org.switchyard.tools.ui.M2EUtils;
+import org.switchyard.tools.ui.common.SwitchYardComponentExtensionManager;
 import org.switchyard.tools.ui.operations.AbstractSwitchYardProjectOperation;
 import org.switchyard.tools.ui.operations.CreateBeanServiceOperation;
 import org.switchyard.tools.ui.operations.CreateSwitchYardProjectOperation;
+import org.switchyard.tools.ui.operations.CreateSwitchYardProjectOperation.NewSwitchYardProjectMetaData;
 import org.switchyard.tools.ui.wizards.NewBeanServiceClassWizardPage;
 import org.switchyard.tools.ui.wizards.NewServiceTestClassWizardPage;
 
@@ -82,8 +83,16 @@ public class CreateSwitchYardProjectTest extends AbstractMavenProjectTestCase {
 
         assertTrue("Project already exists.", !newProjectHandle.exists());
 
-        IWorkspaceRunnable op = new CreateSwitchYardProjectOperation(newProjectHandle, null, packageName, groupId,
-                version, runtimeVersion, null);
+        final NewSwitchYardProjectMetaData projectMetaData = new NewSwitchYardProjectMetaData();
+        projectMetaData.setNewProjectHandle(newProjectHandle);
+        projectMetaData.setPackageName(packageName);
+        projectMetaData.setGroupId(groupId);
+        projectMetaData.setProjectVersion(version);
+        projectMetaData.setRuntimeVersion(runtimeVersion);
+        projectMetaData.setComponents(Collections.singleton(SwitchYardComponentExtensionManager.instance()
+                .getRuntimeComponentExtension()));
+
+        IWorkspaceRunnable op = new CreateSwitchYardProjectOperation(projectMetaData, null);
         workspace.run(op, new NullProgressMonitor());
 
         waitForJobsToComplete();
@@ -115,8 +124,8 @@ public class CreateSwitchYardProjectTest extends AbstractMavenProjectTestCase {
                 fp.hasProjectFacet(ProjectFacetsManager.getProjectFacet("java")));
 
         // Test project update
-        op = new AbstractSwitchYardProjectOperation(null, Collections.singleton(M2EUtils.createSwitchYardDependency(
-                "org.switchyard.components", "switchyard-component-bpm")), Collections.<String> emptySet(), true,
+        op = new AbstractSwitchYardProjectOperation(null, Collections.singleton(SwitchYardComponentExtensionManager
+                .instance().getComponentExtension("org.switchyard.components:switchyard-component-bpm")), true,
                 "Testing SwitchYard project update", null) {
 
             @Override

--- a/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validation/add_dependency_pom.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validation/add_dependency_pom.xml
@@ -48,17 +48,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-          <debug>true</debug>
-          <showWarnings>true</showWarnings>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.switchyard</groupId>
         <artifactId>switchyard-plugin</artifactId>
         <version>${switchyard.version}</version>
@@ -71,12 +60,20 @@
         </executions>
         <configuration>
           <scannerClassNames>
-            <param>org.switchyard.component.bean.config.model.BeanSwitchYardScanner</param>
-            <param>org.switchyard.component.camel.config.model.RouteScanner</param>
-            <param>org.switchyard.component.bpm.config.model.BPMSwitchYardScanner</param>
-            <param>org.switchyard.component.rules.config.model.RulesSwitchYardScanner</param>
             <param>org.switchyard.transform.config.model.TransformSwitchYardScanner</param>
+            <param>org.switchyard.component.bpm.config.model.BPMSwitchYardScanner</param>
           </scannerClassNames>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <debug>true</debug>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>
     </plugins>

--- a/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validation/create_service_pom.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validation/create_service_pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>test.project.group</groupId>
   <artifactId>CreateSwitchYardProjectTest</artifactId>
@@ -53,17 +53,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-          <debug>true</debug>
-          <showWarnings>true</showWarnings>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.switchyard</groupId>
         <artifactId>switchyard-plugin</artifactId>
         <version>${switchyard.version}</version>
@@ -76,12 +65,21 @@
         </executions>
         <configuration>
           <scannerClassNames>
-            <param>org.switchyard.component.bean.config.model.BeanSwitchYardScanner</param>
-            <param>org.switchyard.component.camel.config.model.RouteScanner</param>
-            <param>org.switchyard.component.bpm.config.model.BPMSwitchYardScanner</param>
-            <param>org.switchyard.component.rules.config.model.RulesSwitchYardScanner</param>
             <param>org.switchyard.transform.config.model.TransformSwitchYardScanner</param>
+            <param>org.switchyard.component.bpm.config.model.BPMSwitchYardScanner</param>
+            <param>org.switchyard.component.bean.config.model.BeanSwitchYardScanner</param>
           </scannerClassNames>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <debug>true</debug>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
project; significant refactoring/consolidation.

Added property page for configuring SwitchYard runtime version and components.
Added Configure->SwitchYard Capabilities... menu to all maven projects.
Added component selection to new project wizard.

User can also remove components via the property page.
