### PR TITLE
SWITCHYARD-667 tooling to add artifact references to SwitchYard projects

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui/plugin.xml
@@ -2,6 +2,7 @@
 <?eclipse version="3.4"?>
 <plugin>
    <extension-point id="switchYardComponent" name="SwitchYardComponent" schema="schema/switchYardComponent.exsd"/>
+   <extension-point id="repositorySupport" name="RepositorySupport" schema="schema/repositorySupport.exsd"/>
    <extension
          point="org.eclipse.ui.newWizards">
       <category
@@ -239,8 +240,14 @@
         point="org.eclipse.ui.popupMenus">
      <objectContribution
            adaptable="true"
-           id="org.switchyard.tools.ui.configuration.menu"
+           id="org.switchyard.tools.ui.configuration.contribution"
            objectClass="org.eclipse.core.resources.IProject">
+        <visibility>
+           <objectState
+                 name="projectNature"
+                 value="org.eclipse.m2e.core.maven2Nature">
+           </objectState>
+        </visibility>
         <action
               class="org.switchyard.tools.ui.actions.SwitchYardSettingsAction"
               enablesFor="1"
@@ -248,12 +255,45 @@
               label="SwitchYard Capabilities..."
               menubarPath="org.eclipse.ui.projectConfigure/additions">
         </action>
-        <visibility>
-           <objectState
-                 name="projectNature"
-                 value="org.eclipse.m2e.core.maven2Nature">
-           </objectState>
-        </visibility>
+     </objectContribution>
+     <objectContribution
+           adaptable="true"
+           id="org.switchyard.tools.ui.switchyard.contribution"
+           objectClass="org.eclipse.core.resources.IProject">
+        <enablement>
+           <adapt
+                 type="org.eclipse.core.resources.IProject">
+              <test
+                    property="org.eclipse.wst.common.project.facet.core.projectFacet"
+                    value="switchyard.core">
+              </test>
+           </adapt>
+        </enablement>
+        <menu
+              id="org.switchyard.tools.ui.switchyard.menu"
+              label="SwitchYard"
+              path="additions">
+           <groupMarker
+                 name="additions">
+           </groupMarker>
+           <separator
+                 name="capabilities">
+           </separator>
+        </menu>
+        <action
+              class="org.switchyard.tools.ui.actions.SwitchYardSettingsAction"
+              enablesFor="1"
+              id="org.switchyard.tools.ui.configuration.action.settings2"
+              label="Configure Capabilities..."
+              menubarPath="org.switchyard.tools.ui.switchyard.menu/capabilities">
+        </action>
+        <action
+              class="org.switchyard.tools.ui.actions.AddArtifactReferenceAction"
+              enablesFor="1"
+              id="org.switchyard.tools.ui.configuration.action.addArtifactReference"
+              label="Add Artifact Reference..."
+              menubarPath="org.switchyard.tools.ui.switchyard.menu/additions">
+        </action>
      </objectContribution>
   </extension>
   <extension
@@ -370,6 +410,17 @@
            <artifactId>switchyard-component-soap</artifactId>
         </dependency>
      </component>
+  </extension>
+  <extension
+        point="org.switchyard.tools.ui.repositorySupport">
+     <wizard
+           class="org.switchyard.tools.ui.wizards.NewGenericArtifactReferenceWizard"
+           id="org.switchyard.tools.ui.repository.generic"
+           name="Generic Artifact Reference">
+        <description>
+           Adds an &lt;artifact&gt; element to the project&apos;s switchyard.xml file.
+        </description>
+     </wizard>
   </extension>
 
 </plugin>

--- a/eclipse/plugins/org.switchyard.tools.ui/schema/repositorySupport.exsd
+++ b/eclipse/plugins/org.switchyard.tools.ui/schema/repositorySupport.exsd
@@ -1,0 +1,172 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.switchyard.tools.ui" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.switchyard.tools.ui" id="repositorySupport" name="RepositorySupport"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="0" maxOccurs="unbounded">
+            <element ref="wizard"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  a fully qualified identifier of the target extension point
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  an optional identifier of the extension instance
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  an optional name of the extension instance
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="wizard">
+      <complexType>
+         <sequence>
+            <element ref="description" minOccurs="0" maxOccurs="1"/>
+         </sequence>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  a unique name that can be used to identify this wizard
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  a translatable name of the wizard that will be used in the dialog box
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="icon" type="string">
+            <annotation>
+               <documentation>
+                  a relative path of an icon that will be used together with the name to represent the wizard 
+as one of the choices in the creation dialog box.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="resource"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  a fully qualified name of the Java class implementing &lt;samp&gt;org.eclipse.ui.IWorkbenchWizard&lt;/samp&gt;.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="org.switchyard.tools.ui.wizards.NewArtifactReferenceWizard:org.eclipse.ui.IWorkbenchWizard"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="helpHref" type="string">
+            <annotation>
+               <documentation>
+                  a help url that can describe this wizard in detail.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="description" type="string">
+      <annotation>
+         <appinfo>
+            <meta.element translatable="true"/>
+         </appinfo>
+         <documentation>
+            an optional subelement whose body contains a short text describing what the wizard will do when started
+         </documentation>
+      </annotation>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         Following is an example of creation wizard configuration: 
+&lt;p&gt;
+&lt;pre&gt;
+   &lt;extension point=&quot;org.eclipse.ui.repositorySupport&quot;&gt; 
+      &lt;wizard 
+          id=&quot;com.xyz.wizard1&quot; 
+          name=&quot;XYZ artifact&quot; 
+          icon=&quot;./icons/XYZwizard1.gif&quot; 
+          class=&quot;com.xyz.XYZWizard1&quot;&gt; 
+          &lt;description&gt; 
+              Create a simple XYZ artifact reference and set initial content 
+          &lt;/description&gt; 
+      &lt;/wizard&gt; 
+   &lt;/extension&gt; 
+&lt;/pre&gt;
+&lt;/p&gt;
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiInfo"/>
+      </appinfo>
+      <documentation>
+         The value of the class attribute must represent a class 
+that implements &lt;samp&gt;org.eclipse.ui.IWorkbenchWizard&lt;/samp&gt;. 
+The wizard must extend &lt;samp&gt;org.switchyard.tools.ui.wizards.NewArtifactReferenceWizard&lt;/samp&gt;.
+      </documentation>
+   </annotation>
+
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         SwitchYard come with a wizard for creating generic artifact references.
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="copyright"/>
+      </appinfo>
+      <documentation>
+         Copyright (c) 2002, 2005 IBM Corporation and others.&lt;br&gt;
+All rights reserved. This program and the accompanying materials are made
+available under the terms of the Eclipse Public License v1.0 which accompanies
+this distribution, and is available at &lt;a 
+href=&quot;http://www.eclipse.org/legal/epl-v10.html&quot;&gt;http://www.eclipse.org/legal/epl-v10.html&lt;/a&gt;
+      </documentation>
+   </annotation>
+
+</schema>

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/actions/AddArtifactReferenceAction.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/actions/AddArtifactReferenceAction.java
@@ -1,0 +1,91 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.actions;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.ui.IObjectActionDelegate;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.actions.ActionDelegate;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.wizards.RepositoryArtifactReferenceWizard;
+
+/**
+ * AddArtifactReferenceAction
+ * 
+ * <p/>
+ * Action which displays the new artifact reference wizard, allowing the user to
+ * create a new repository artifact reference.
+ * 
+ * @author Rob Cernich
+ */
+public class AddArtifactReferenceAction extends ActionDelegate implements IObjectActionDelegate {
+
+    private IProject _project;
+    private IWorkbenchPart _targetPart;
+
+    @Override
+    public void setActivePart(IAction action, IWorkbenchPart targetPart) {
+        _targetPart = targetPart;
+    }
+
+    @Override
+    public void selectionChanged(IAction action, ISelection selection) {
+        super.selectionChanged(action, selection);
+        _project = null;
+        if (selection.isEmpty() || !(selection instanceof IStructuredSelection)) {
+            return;
+        }
+        Object obj = ((IStructuredSelection) selection).getFirstElement();
+        if (obj instanceof IProject) {
+            _project = (IProject) obj;
+        }
+    }
+
+    @Override
+    public void run(IAction action) {
+        if (_project == null || _targetPart == null) {
+            return;
+        }
+
+        IDialogSettings workbenchSettings = Activator.getDefault().getDialogSettings();
+        IDialogSettings wizardSettings = workbenchSettings.getSection("AddArtifactReferenceAction"); //$NON-NLS-1$
+        if (wizardSettings == null) {
+            wizardSettings = workbenchSettings.addNewSection("AddArtifactReferenceAction"); //$NON-NLS-1$
+        }
+
+        RepositoryArtifactReferenceWizard wizard = new RepositoryArtifactReferenceWizard();
+        wizard.setDialogSettings(wizardSettings);
+        wizard.init(_targetPart.getSite().getWorkbenchWindow().getWorkbench(), new StructuredSelection(_project));
+        new WizardDialog(_targetPart.getSite().getShell(), wizard).open();
+    }
+
+    @Override
+    public void dispose() {
+        _project = null;
+        _targetPart = null;
+        super.dispose();
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ISwitchYardProject.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ISwitchYardProject.java
@@ -18,11 +18,15 @@
  */
 package org.switchyard.tools.ui.common;
 
+import java.io.IOException;
 import java.util.Set;
 
 import org.apache.maven.project.MavenProject;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
 
 /**
  * ISwitchYardProject
@@ -75,6 +79,27 @@ public interface ISwitchYardProject {
      * @return true if the meta-data for this project needs to be updated.
      */
     boolean needsLoading();
+
+    /**
+     * Scans resource folders for the first instance of META-INF/switchyard.xml.
+     * If one is not located, the first applicable resource folder will be used.
+     * 
+     * @return the location of the switchyard.xml file.
+     */
+    public IFile getSwitchYardConfigurationFile();
+
+    /**
+     * Loads the SwitchYardModel associated with this project. This method will
+     * return an empty model if a switchyard.xml file does not exist within the
+     * project.
+     * 
+     * @param monitor the progress monitor.
+     * @return the SwitchYardModel associated with this project.
+     * @throws CoreException if an error occurs accessing the workspace
+     *             resource.
+     * @throws IOException if an error occurs loading the model.
+     */
+    public SwitchYardModel loadSwitchYardModel(IProgressMonitor monitor) throws CoreException, IOException;
 
     /**
      * Force loading of project meta-data. This may be a long running operation

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/SwitchYardProjectWorkingCopy.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/SwitchYardProjectWorkingCopy.java
@@ -24,6 +24,7 @@ import static org.switchyard.tools.ui.M2EUtils.createJBossPublicRepository;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -35,6 +36,7 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Repository;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -44,6 +46,7 @@ import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.project.MavenUpdateRequest;
 import org.eclipse.m2e.core.ui.internal.UpdateConfigurationJob;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.tools.ui.Activator;
 import org.switchyard.tools.ui.common.ISwitchYardComponentExtension;
 import org.switchyard.tools.ui.common.ISwitchYardProjectWorkingCopy;
@@ -112,6 +115,16 @@ public class SwitchYardProjectWorkingCopy implements ISwitchYardProjectWorkingCo
     @Override
     public String getRawVersionString() {
         return _switchYardProject.getRawVersionString();
+    }
+
+    @Override
+    public IFile getSwitchYardConfigurationFile() {
+        return _switchYardProject.getSwitchYardConfigurationFile();
+    }
+
+    @Override
+    public SwitchYardModel loadSwitchYardModel(IProgressMonitor monitor) throws CoreException, IOException {
+        return _switchYardProject.loadSwitchYardModel(monitor);
     }
 
     @Override

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateArtifactReferenceOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateArtifactReferenceOperation.java
@@ -1,0 +1,156 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.operations;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.ui.ide.undo.CreateFileOperation;
+import org.switchyard.config.OutputKey;
+import org.switchyard.config.model.ModelPuller;
+import org.switchyard.config.model.switchyard.ArtifactModel;
+import org.switchyard.config.model.switchyard.ArtifactsModel;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.common.ISwitchYardProject;
+
+/**
+ * CreateArtifactReferenceOperation
+ * 
+ * <p/>
+ * Creates a new &lt;artifact&gt; element in a switchyard.xml file.
+ * 
+ * @author Rob Cernich
+ */
+public class CreateArtifactReferenceOperation implements IWorkspaceRunnable {
+
+    private ISwitchYardProject _switchYardProject;
+    private String _name;
+    private String _url;
+    private IWorkspaceRunnable _downloadOperation;
+    private IAdaptable _uiInfo;
+
+    /**
+     * Create a new CreateArtifactReferenceOperation.
+     * 
+     * @param switchYardProject the Switchyard project (used to resolve the
+     *            configuration file).
+     * @param name the artifact name
+     * @param url the artifact url
+     * @param downloadOperation the operation used to download the artifact; may
+     *            be null.
+     * @param uiInfo adaptable for UI Shell, may be null.
+     */
+    public CreateArtifactReferenceOperation(ISwitchYardProject switchYardProject, String name, String url,
+            IWorkspaceRunnable downloadOperation, IAdaptable uiInfo) {
+        _switchYardProject = switchYardProject;
+        _name = name;
+        _url = url;
+        _downloadOperation = downloadOperation;
+    }
+
+    @Override
+    public void run(IProgressMonitor monitor) throws CoreException {
+        monitor.beginTask("Adding artifact reference to SwitchYard project.", 200);
+        try {
+            IProgressMonitor subMonitor = new SubProgressMonitor(monitor, 100,
+                    SubProgressMonitor.PREPEND_MAIN_LABEL_TO_SUBTASK);
+            try {
+                monitor.subTask("Updating switchyard.xml file.");
+                updateSwitchYardFile(subMonitor);
+            } catch (CoreException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                        "Error occurred updating switchyard.xml file.", e));
+            } finally {
+                subMonitor.done();
+                subMonitor.setTaskName("");
+            }
+
+            if (_downloadOperation == null) {
+                return;
+            }
+
+            subMonitor = new SubProgressMonitor(monitor, 100, SubProgressMonitor.PREPEND_MAIN_LABEL_TO_SUBTASK);
+            monitor.subTask("Downloading artifact resource.");
+            try {
+                _downloadOperation.run(subMonitor);
+            } catch (CoreException e) {
+                throw new CoreException(new Status(Status.WARNING, Activator.PLUGIN_ID,
+                        "Error occurred while downloading artifact resource.", e));
+            }
+        } finally {
+            monitor.subTask("");
+            monitor.done();
+        }
+    }
+
+    private void updateSwitchYardFile(IProgressMonitor monitor) throws CoreException, ExecutionException, IOException {
+        monitor.beginTask("Updating switchyard.xml file.", 200);
+
+        monitor.subTask("Loading switchyard.xml file.");
+        SwitchYardModel switchYardModel = _switchYardProject.loadSwitchYardModel(new NullProgressMonitor());
+        monitor.worked(100);
+        
+        IFile switchYardFile = _switchYardProject.getSwitchYardConfigurationFile();
+        ArtifactsModel artifacts = switchYardModel.getArtifacts();
+        if (artifacts == null) {
+            artifacts = new ModelPuller<ArtifactsModel>().pull(new QName(SwitchYardModel.DEFAULT_NAMESPACE,
+                    ArtifactsModel.ARTIFACTS));
+            switchYardModel.setArtifacts(artifacts);
+        }
+        ArtifactModel artifact = new ModelPuller<ArtifactModel>().pull(new QName(SwitchYardModel.DEFAULT_NAMESPACE,
+                ArtifactModel.ARTIFACT));
+        artifact.setName(_name);
+        artifact.setURL(_url);
+        artifacts.addArtifact(artifact);
+        
+        monitor.subTask("Writing udpated switchyard.xml");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        switchYardModel.getModelConfiguration().write(baos, new OutputKey[0]);
+        if (switchYardFile.exists()) {
+            switchYardFile.setContents(new ByteArrayInputStream(baos.toByteArray()), true, true,
+                    new SubProgressMonitor(monitor, 100));
+        } else {
+            try {
+                new CreateFileOperation(switchYardFile, null, new ByteArrayInputStream(baos.toByteArray()),
+                        "Creating switchyard.xml file.").execute(new SubProgressMonitor(monitor, 100), _uiInfo);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof CoreException) {
+                    throw (CoreException) e.getCause();
+                }
+                throw e;
+            }
+        }
+
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/ArtifactDetailsWizardPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/ArtifactDetailsWizardPage.java
@@ -1,0 +1,198 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.wizards;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.eclipse.jface.wizard.IWizard;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+import org.switchyard.config.model.switchyard.ArtifactModel;
+import org.switchyard.config.model.switchyard.ArtifactsModel;
+
+/**
+ * ArtifactDetailsWizardPage
+ * 
+ * <p/>
+ * Wizard page for collecting details about a referenced artifact.
+ * 
+ * @author Rob Cernich
+ */
+public class ArtifactDetailsWizardPage extends WizardPage {
+
+    private boolean _supportsDownload;
+    private Text _nameText;
+    private Text _urlText;
+    private Button _downloadCheckbox;
+
+    /**
+     * Create a new ArtifactDetailsWizardPage.
+     * 
+     * @param supportsDownload true if the containing wizard supports download.
+     */
+    protected ArtifactDetailsWizardPage(boolean supportsDownload) {
+        super(ArtifactDetailsWizardPage.class.getName());
+        _supportsDownload = supportsDownload;
+        setTitle("Artifact Details");
+        setDescription("Specify details about the artifact reference.");
+    }
+
+    @Override
+    public void createControl(Composite parent) {
+        Composite content = new Composite(parent, SWT.NONE);
+        content.setLayout(new GridLayout(2, false));
+
+        Label label = new Label(content, SWT.NONE);
+        label.setText("Artifact Name:");
+
+        _nameText = new Text(content, SWT.SINGLE | SWT.BORDER);
+        _nameText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        _nameText.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent e) {
+                validate();
+            }
+        });
+
+        label = new Label(content, SWT.NONE);
+        label.setText("Artifact URL:");
+
+        _urlText = new Text(content, SWT.SINGLE | SWT.BORDER);
+        _urlText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+        _urlText.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent e) {
+                validate();
+            }
+        });
+
+        _downloadCheckbox = new Button(content, SWT.CHECK);
+        _downloadCheckbox.setText("Download artifact to workspace?");
+        _downloadCheckbox.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false, 2, 1));
+        _downloadCheckbox.setEnabled(_supportsDownload);
+        _downloadCheckbox.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent event) {
+                getContainer().updateButtons();
+            }
+        });
+
+        validate();
+        setErrorMessage(null);
+
+        _nameText.setFocus();
+        
+        setControl(content);
+    }
+
+    /**
+     * @return the specified name
+     */
+    public String getArtifactName() {
+        if (_nameText == null) {
+            return null;
+        }
+        return _nameText.getText();
+    }
+
+    /**
+     * @param name the specified name
+     */
+    public void setArtifactName(String name) {
+        if (_nameText == null) {
+            return;
+        }
+        _nameText.setText(name == null ? "" : name);
+    }
+
+    /**
+     * @return the specified url
+     */
+    public String getArtifactURL() {
+        if (_urlText == null) {
+            return null;
+        }
+        return _urlText.getText();
+    }
+
+    /**
+     * @param url the specified url
+     */
+    public void setArtifactURL(String url) {
+        if (_urlText == null) {
+            return;
+        }
+        _urlText.setText(url == null ? "" : url);
+    }
+
+    /**
+     * @return true if the wizard should attempt to download the artifact on
+     *         finish
+     */
+    public boolean isDownloadArtifact() {
+        if (_downloadCheckbox == null) {
+            return false;
+        }
+        return _downloadCheckbox.getSelection();
+    }
+
+    private void validate() {
+        if (_nameText.getText().isEmpty()) {
+            setErrorMessage("Must specify a name.");
+        } else if (isDuplicateName(_nameText.getText())) {
+            setErrorMessage("An artifact with the specified name already exists.  Please specify a unique name.");
+        } else if (_urlText.getText().isEmpty()) {
+            setErrorMessage("Must specify a URL.");
+        } else {
+            try {
+                new URL(_urlText.getText());
+                setErrorMessage(null);
+            } catch (MalformedURLException e) {
+                setErrorMessage("The specified URL is invalid: " + e.getLocalizedMessage());
+            }
+        }
+        setPageComplete(getErrorMessage() == null);
+    }
+
+    private boolean isDuplicateName(String name) {
+        IWizard wizard = getWizard();
+        if (wizard instanceof NewArtifactReferenceWizard) {
+            ArtifactsModel artifacts = ((NewArtifactReferenceWizard) wizard).getArtifacts();
+            if (artifacts == null) {
+                return false;
+            }
+            for (ArtifactModel artifact : artifacts.getArtifacts()) {
+                if (name.equals(artifact.getName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewArtifactReferenceWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewArtifactReferenceWizard.java
@@ -1,0 +1,259 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.wizards;
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.xml.namespace.QName;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.operation.IRunnableWithProgress;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.IWizardPage;
+import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWizard;
+import org.eclipse.ui.ide.undo.WorkspaceUndoUtil;
+import org.switchyard.config.model.ModelPuller;
+import org.switchyard.config.model.switchyard.ArtifactsModel;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.tools.ui.Activator;
+import org.switchyard.tools.ui.common.ISwitchYardProject;
+import org.switchyard.tools.ui.common.impl.SwitchYardProject;
+import org.switchyard.tools.ui.operations.CreateArtifactReferenceOperation;
+
+/**
+ * NewArtifactReferenceWizard
+ * 
+ * <p/>
+ * Creates a new &lt;artifact&gt; element in a switchyard.xml file.
+ * 
+ * This is the base wizard used by extensions.
+ * 
+ * @author Rob Cernich
+ */
+public abstract class NewArtifactReferenceWizard extends Wizard implements IWorkbenchWizard {
+
+    private boolean _supportsDownload;
+    private IWorkbench _workbench;
+    private IProject _project;
+    private ISwitchYardProject _switchYardProject;
+    private SwitchYardModel _switchYardModel;
+    private ArtifactDetailsWizardPage _artifactDetailsPage;
+
+    protected NewArtifactReferenceWizard(boolean supportsDownload) {
+        super();
+        _supportsDownload = supportsDownload;
+    }
+
+    @Override
+    public void init(IWorkbench workbench, IStructuredSelection selection) {
+        _workbench = workbench;
+        _project = (IProject) selection.getFirstElement();
+    }
+
+    @Override
+    public void createPageControls(Composite pageContainer) {
+        super.createPageControls(pageContainer);
+        // take the opportunity to initialize state
+        loadSwitchYardModel();
+    }
+
+    @Override
+    public boolean performFinish() {
+        IWorkspaceRunnable downloadOperation = null;
+        if (_artifactDetailsPage != null && _artifactDetailsPage.isDownloadArtifact()) {
+            downloadOperation = createDownloadOperation();
+        }
+        final CreateArtifactReferenceOperation op = new CreateArtifactReferenceOperation(_switchYardProject,
+                getArtifactName(), getArtifactURL(), downloadOperation, WorkspaceUndoUtil.getUIInfoAdapter(getShell()));
+        try {
+            getContainer().run(true, true, new IRunnableWithProgress() {
+                @Override
+                public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+                    try {
+                        ResourcesPlugin.getWorkspace().run(op, monitor);
+                    } catch (CoreException e) {
+                        throw new InvocationTargetException(e);
+                    }
+                }
+            });
+        } catch (InterruptedException e) {
+            return false;
+        } catch (InvocationTargetException e) {
+            boolean partialSuccess = false;
+            Throwable realException = e.getTargetException();
+            if (realException instanceof CoreException) {
+                partialSuccess = ((CoreException) realException).getStatus().getSeverity() < Status.ERROR;
+                Activator.getDefault().getLog().log(((CoreException) realException).getStatus());
+            } else {
+                Activator
+                        .getDefault()
+                        .getLog()
+                        .log(new Status(Status.ERROR, Activator.PLUGIN_ID,
+                                "Error adding artifact reference to SwitchYard project.", realException));
+            }
+            MessageDialog.openError(getShell(), "Error Adding Artifact Reference", realException.getMessage());
+            return partialSuccess;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return an runnable that will download the repository artifact.
+     */
+    protected IWorkspaceRunnable createDownloadOperation() {
+        return null;
+    }
+
+    /**
+     * Provides access to the project's ArtifactsModel. This may be used by the
+     * wizard or its pages for constraining properties for new artifacts (e.g.
+     * to prevent duplicate names or URLs).
+     * 
+     * @return the ArtifactsModel defined by this project.
+     */
+    public ArtifactsModel getArtifacts() {
+        return _switchYardModel.getArtifacts();
+    }
+
+    /**
+     * Provides access to the URL of a selected provider resource. This may be
+     * used by the ArtifactDetailsWizardPage to initialize properties of the
+     * artifact being created.
+     * 
+     * @return the URL of the selected provider resource.
+     */
+    protected String getProviderURL() {
+        return null;
+    }
+
+    /**
+     * Provides access to the URL of a selected provider resource. This may be
+     * used by the ArtifactDetailsWizardPage to initialize properties of the
+     * artifact being created.
+     * 
+     * @return the name of the selected provider resource.
+     */
+    protected String getProviderName() {
+        return null;
+    }
+
+    /**
+     * @return the artifact details page, creating the page if necessary.
+     */
+    protected ArtifactDetailsWizardPage getArtifactDetailsPage() {
+        if (_artifactDetailsPage == null) {
+            _artifactDetailsPage = new ArtifactDetailsWizardPage(_supportsDownload);
+        }
+        return _artifactDetailsPage;
+    }
+
+    protected String getArtifactName() {
+        if (_artifactDetailsPage == null) {
+            return null;
+        }
+        return _artifactDetailsPage.getArtifactName();
+    }
+
+    protected String getArtifactURL() {
+        if (_artifactDetailsPage == null) {
+            return null;
+        }
+        return _artifactDetailsPage.getArtifactURL();
+    }
+
+    @Override
+    public IWizardPage getNextPage(IWizardPage page) {
+        page = super.getNextPage(page);
+        if (page == _artifactDetailsPage && _artifactDetailsPage != null) {
+            updateArtifactDetails();
+        }
+        return page;
+    }
+
+    protected IWorkbench getWorkbench() {
+        return _workbench;
+    }
+
+    protected IProject getProject() {
+        return _project;
+    }
+
+    /**
+     * Update the name and URL controls to match the provider information.
+     */
+    protected void updateArtifactDetails() {
+        String temp = getProviderName();
+        if (temp != null && temp.length() > 0) {
+            _artifactDetailsPage.setArtifactName(temp);
+        }
+        temp = getProviderURL();
+        if (temp != null && temp.length() > 0) {
+            _artifactDetailsPage.setArtifactURL(temp);
+        }
+    }
+
+    @Override
+    public boolean canFinish() {
+        if (_artifactDetailsPage == null) {
+            return super.canFinish();
+        }
+        IWizardPage currentPage = getContainer().getCurrentPage();
+        for (IWizardPage page : getPages()) {
+            if (page == _artifactDetailsPage) {
+                break;
+            } else if (page == currentPage) {
+                // make sure we show the artifact details page
+                return false;
+            }
+        }
+        return super.canFinish();
+    }
+
+    private void loadSwitchYardModel() {
+        _switchYardProject = new SwitchYardProject(_project);
+        try {
+            getContainer().run(false, true, new IRunnableWithProgress() {
+                @Override
+                public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+                    try {
+                        _switchYardModel = _switchYardProject.loadSwitchYardModel(monitor);
+                    } catch (Exception e) {
+                        throw new InvocationTargetException(e);
+                    }
+                }
+            });
+        } catch (Exception e) {
+            e.fillInStackTrace();
+        }
+        if (_switchYardModel == null) {
+            _switchYardModel = new ModelPuller<SwitchYardModel>().pull(new QName(SwitchYardModel.DEFAULT_NAMESPACE,
+                    SwitchYardModel.SWITCHYARD));
+        }
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewArtifactReferenceWizardRegistry.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewArtifactReferenceWizardRegistry.java
@@ -1,0 +1,54 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.wizards;
+
+import org.eclipse.ui.internal.wizards.AbstractExtensionWizardRegistry;
+import org.switchyard.tools.ui.Activator;
+
+/**
+ * NewArtifactReferenceWizardRegistry
+ * 
+ * <p/>
+ * Manages wizards contributed by a repository provider.
+ * 
+ * @author Rob Cernich
+ */
+@SuppressWarnings("restriction")
+public class NewArtifactReferenceWizardRegistry extends AbstractExtensionWizardRegistry {
+
+    private static final NewArtifactReferenceWizardRegistry INSTANCE = new NewArtifactReferenceWizardRegistry();
+
+    /**
+     * @return the registry instance.
+     */
+    public static NewArtifactReferenceWizardRegistry instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected String getExtensionPoint() {
+        return "repositorySupport";
+    }
+
+    @Override
+    protected String getPlugin() {
+        return Activator.PLUGIN_ID;
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewGenericArtifactReferenceWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewGenericArtifactReferenceWizard.java
@@ -1,0 +1,46 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.wizards;
+
+import org.eclipse.ui.IWorkbenchWizard;
+
+/**
+ * NewGenericArtifactReferenceWizard
+ * 
+ * <p/>
+ * Wizard supporting the creation of a "generic" artifact reference.
+ * 
+ * @author Rob Cernich
+ */
+public class NewGenericArtifactReferenceWizard extends NewArtifactReferenceWizard implements IWorkbenchWizard {
+
+    /**
+     * Create a new NewGenericArtifactReferenceWizard.
+     */
+    public NewGenericArtifactReferenceWizard() {
+        super(false);
+        setWindowTitle("Generic Artifact Reference");
+    }
+
+    @Override
+    public void addPages() {
+        addPage(getArtifactDetailsPage());
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/RepositoryArtifactReferenceWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/RepositoryArtifactReferenceWizard.java
@@ -1,0 +1,103 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.tools.ui.wizards;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.IWizardNode;
+import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.ui.INewWizard;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWizard;
+import org.eclipse.ui.internal.dialogs.WizardCollectionElement;
+import org.eclipse.ui.internal.dialogs.WorkbenchWizardElement;
+import org.eclipse.ui.internal.dialogs.WorkbenchWizardListSelectionPage;
+import org.eclipse.ui.internal.dialogs.WorkbenchWizardNode;
+import org.eclipse.ui.internal.registry.WizardsRegistryReader;
+
+/**
+ * RepositoryArtifactReferenceWizard
+ * 
+ * <p/>
+ * Wizard supporting the creation of artifact references.
+ * 
+ * @author Rob Cernich
+ */
+@SuppressWarnings("restriction")
+public class RepositoryArtifactReferenceWizard extends Wizard implements INewWizard {
+
+    private class WizardSelectionPage extends WorkbenchWizardListSelectionPage {
+
+        public WizardSelectionPage() {
+            super(_workbench, _selection, _wizardsList, "Wizards:", "org.switchyard.tools.ui.repositorySupport");
+            setTitle("Select a wizard");
+        }
+
+        @Override
+        protected IWizardNode createWizardNode(WorkbenchWizardElement element) {
+            return new WorkbenchWizardNode(this, element) {
+                public IWorkbenchWizard createWizard() throws CoreException {
+                    return wizardElement.createWizard();
+                }
+            };
+        }
+
+    }
+
+    private IWorkbench _workbench;
+    private IStructuredSelection _selection;
+    private WizardCollectionElement _wizardsList;
+    private WizardSelectionPage _selectionPage;
+
+    /**
+     * Create a new RepositoryArtifactReferenceWizard.
+     */
+    public RepositoryArtifactReferenceWizard() {
+        super();
+        setForcePreviousAndNextButtons(true);
+        setNeedsProgressMonitor(true);
+        setWindowTitle("Add Artifact Reference");
+    }
+
+    /**
+     * Initializes the wizard state.
+     * 
+     * @param workbench the workbench.
+     * @param selection the selection to operate on.
+     */
+    public void init(IWorkbench workbench, IStructuredSelection selection) {
+        _workbench = workbench;
+        _selection = selection;
+    }
+
+    @Override
+    public void addPages() {
+        _wizardsList = ((WizardCollectionElement) NewArtifactReferenceWizardRegistry.instance().getRootCategory())
+                .findCategory(WizardsRegistryReader.UNCATEGORIZED_WIZARD_CATEGORY);
+        _selectionPage = new WizardSelectionPage();
+        addPage(_selectionPage);
+    }
+
+    @Override
+    public boolean performFinish() {
+        _selectionPage.saveWidgetValues();
+        return true;
+    }
+
+}


### PR DESCRIPTION
Added "SwitchYard" context menu that is active for SwitchYard projects.
SwitchYard menu contains actions for:
- adding artifact references
- configuring capabilities (same as configure -> switchyard capabilities...)
  Added extension point for contributing functionality specific to particular repository providers.
  Added support for adding simple (generic) artifact references (manually entered name and url; a generic repository provider).
