### PR TITLE
SWITCHYARD-855 when changing implementations, do not update component services/references

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/implementation/CreateImplementationFeature.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/implementation/CreateImplementationFeature.java
@@ -63,27 +63,32 @@ public class CreateImplementationFeature extends CreateTypeFeature<Implementatio
     @Override
     protected Object[] updateContainer(ICreateContext context, Implementation newObject) {
         final List<Object> added = new ArrayList<Object>(3);
-        final IImplementationTypeFactory factory = (IImplementationTypeFactory) getFactory();
         final Component component = getContainerObject(context);
+
         // add the implementation
         component.getImplementationGroup().set(newObject.getDocumentFeature(), newObject);
         added.add(newObject);
 
-        // add any new services
-        final List<ComponentService> services = factory.getImplementationServices();
-        if (services != null) {
-            for (ComponentService service : services) {
-                component.getService().add(service);
-                added.add(service);
+        final IImplementationTypeFactory factory = (IImplementationTypeFactory) getFactory();
+        if (component.getService().size() == 0) {
+            // add any new services
+            final List<ComponentService> services = factory.getImplementationServices();
+            if (services != null) {
+                for (ComponentService service : services) {
+                    component.getService().add(service);
+                    added.add(service);
+                }
             }
         }
 
-        // add any new references
-        final List<ComponentReference> references = factory.getImplementationReferences();
-        if (references != null) {
-            for (ComponentReference reference : references) {
-                component.getReference().add(reference);
-                added.add(reference);
+        if (component.getReference().size() == 0) {
+            // add any new references
+            final List<ComponentReference> references = factory.getImplementationReferences();
+            if (references != null) {
+                for (ComponentReference reference : references) {
+                    component.getReference().add(reference);
+                    added.add(reference);
+                }
             }
         }
 


### PR DESCRIPTION
service is added if no service is defined on the component.
references are added if no references are defined on the component.

this seems the best compromise to catch cases where the user has already defined service/references on an abstract component, plus automatically adding things when the previous component/implementation did not specify them, but the new implementation does.
