### PR TITLE
SWITCHYARD-873 add support for creating SwitchYard Service tasks in bpmn editor

### DIFF
--- a/eclipse/features/org.switchyard.tools.editor.feature/feature.xml
+++ b/eclipse/features/org.switchyard.tools.editor.feature/feature.xml
@@ -29,4 +29,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.switchyard.tools.ui.bpmn2"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/META-INF/MANIFEST.MF
@@ -1,0 +1,25 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: SwitchYard Tools BPMN2 Editor Extensions
+Bundle-SymbolicName: org.switchyard.tools.ui.bpmn2;singleton:=true
+Bundle-Version: 0.5.0.qualifier
+Bundle-Vendor: www.jboss.org
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-ActivationPolicy: lazy
+Require-Bundle: org.eclipse.ui,
+ org.eclipse.core.runtime,
+ org.eclipse.core.resources,
+ org.eclipse.ui.views.properties.tabbed,
+ org.switchyard.tools.ui,
+ org.switchyard.tools.ui.editor,
+ org.eclipse.wst.common.project.facet.core;bundle-version="1.4.200",
+ org.eclipse.graphiti,
+ org.eclipse.graphiti.ui,
+ org.eclipse.gef,
+ org.eclipse.emf.transaction,
+ org.eclipse.bpmn2;resolution:=optional,
+ org.eclipse.bpmn2.modeler.core;bundle-version="[0.0.1,0.1.0)";resolution:=optional,
+ org.eclipse.bpmn2.modeler.ui;bundle-version="[0.0.1,0.1.0)";resolution:=optional,
+ org.eclipse.bpmn2.modeler.runtime.jboss.jbpm5;bundle-version="[0.0.1,0.1.0)";resolution:=optional
+Bundle-ClassPath: .
+Bundle-Activator: org.switchyard.tools.ui.bpmn2.Activator

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/build.properties
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/plugin.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.bpmn2.modeler.runtime">
+
+		<propertyTab
+			id="org.switchyard.tools.ui.bpmn2.switchYardServiceTask.tab"
+			replaceTab="bpmn2.jbpm.customTask.tab"
+			class="org.switchyard.tools.ui.bpmn2.SwitchYardServiceTaskPropertySection"
+			label="SwitchYard Service Task">
+		</propertyTab>
+
+      <customTask
+            description="This task represents the invocation of a SwitchYard service."
+            featureContainer="org.switchyard.tools.ui.bpmn2.SwitchYardServiceTaskFeatureContainer"
+            id="org.switchyard.tools.ui.bpmn2.switchYardServiceTask"
+            name="SwitchYard Service"
+            runtimeId="org.jboss.runtime.jbpm5"
+            type="Task">
+
+			<property
+         name="taskName"
+         value="SwitchYard Service">
+			</property>
+			<property
+         name="icon"
+         value="org.switchyard.tools.ui.editor.SwitchYard.16">
+			</property>
+
+			<property name="ioSpecification">
+				<value>
+					<property name="dataInputs">
+						<value>
+							<property
+             description="The name of the SwitchYard service to be invoked."
+             name="name"
+             value="ServiceName"/>
+						</value>
+					</property>
+					<property name="dataInputs">
+						<value>
+							<property
+             description="The name of the operation to be invoked on the SwitchYard service."
+             name="name"
+             value="ServiceOperationName"/>
+						</value>
+					</property>
+					<property name="dataInputs">
+						<value>
+							<property
+             description="The name of the property holding the input message to be passed to the SwitchYard service (default: messageContentIn)"
+             name="name"
+             value="MessageContentInName"/>
+						</value>
+					</property>
+					<property name="dataInputs">
+						<value>
+							<property
+             description="The name of the property to which the output message from the SwitchYard service will be stored (default: messageContentOut)"
+             name="name"
+             value="MessageContentOutName"/>
+						</value>
+					</property>
+					<property name="dataInputs">
+						<value>
+							<property
+             description="This is used to store the input message to be passed to the SwitchYard servce.  It must match the &quot;MessageContentInName&quot; property."
+             name="name"
+             value="messageContentIn"/>
+						</value>
+					</property>
+					<property name="dataOutputs">
+						<value>
+							<property
+             description="This is used to store the output message from the SwitchYard servce.  It must match the &quot;MessageContentOutName&quot; property."
+             name="name"
+             value="messageContentOut"/>
+						</value>
+					</property>
+
+					<property name="inputSets">
+						<value>
+							<property name="dataInputRefs" ref="ioSpecification/dataInputs#0"/>
+							<property name="dataInputRefs" ref="ioSpecification/dataInputs#1"/>
+							<property name="dataInputRefs" ref="ioSpecification/dataInputs#2"/>
+							<property name="dataInputRefs" ref="ioSpecification/dataInputs#3"/>
+							<property name="dataInputRefs" ref="ioSpecification/dataInputs#4"/>
+						</value>
+					</property>
+					<property name="outputSets">
+						<value>
+							<property name="dataOutputRefs" ref="ioSpecification/dataOutputs#0"/>
+						</value>
+					</property>
+				</value>
+			</property>
+			<property name="dataInputAssociations">
+				<value>
+					<property name="targetRef" ref="ioSpecification/dataInputs#0"/>
+				</value>
+			</property>
+			<property name="dataInputAssociations">
+				<value>
+					<property name="targetRef" ref="ioSpecification/dataInputs#1"/>
+				</value>
+			</property>
+			<property name="dataInputAssociations">
+				<value>
+					<property name="targetRef" ref="ioSpecification/dataInputs#2"/>
+				</value>
+			</property>
+			<property name="dataInputAssociations">
+				<value>
+					<property name="targetRef" ref="ioSpecification/dataInputs#3"/>
+				</value>
+			</property>
+			<property name="dataInputAssociations">
+				<value>
+					<property name="targetRef" ref="ioSpecification/dataInputs#4"/>
+				</value>
+			</property>
+			<property name="dataOutputAssociations">
+				<value>
+					<property name="sourceRef" ref="ioSpecification/dataOutputs#0"/>
+				</value>
+			</property>
+      </customTask>
+   </extension>
+   <!-- This could be fragile.  We do this to make sure the SwitchYard images are loaded for use in the BPMN2 Editor. -->
+   <!-- Make sure class is null so it doesn't hork up the real diagram provider. -->
+	<extension point="org.eclipse.graphiti.ui.diagramTypeProviders">
+		<diagramTypeProvider
+			description="This is the editor for the BPMN2 diagram"
+			id="org.eclipse.bpmn2.modeler.ui.diagram.MainBPMNDiagramType" name="BPMN2 Editor">
+			<imageProvider id="org.switchyard.tools.ui.editor.ImageProvider"/>
+		</diagramTypeProvider>
+	</extension>
+
+</plugin>

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>switchyard-tools-eclipse-plugins</artifactId>
+    <groupId>org.switchyard.tools</groupId>
+    <version>0.5.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>org.switchyard.tools.ui.bpmn2</artifactId>
+  <packaging>eclipse-plugin</packaging>
+  <name>SwitchYard: Eclipse BPMN2 Editor Extensions</name>
+  <description>Provides editor extensions for using SwitchYard services in BPMN2 processes.</description>
+
+</project>

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/Activator.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/Activator.java
@@ -1,0 +1,68 @@
+/*************************************************************************************
+ * Copyright (c) 2011 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.bpmn2;
+
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle.
+ */
+public class Activator extends AbstractUIPlugin {
+
+    /** The PLUGIN_ID. */
+    public static final String PLUGIN_ID = "org.switchyard.tools.ui.bpmn2"; //$NON-NLS-1$
+
+    // The shared instance
+    private static Activator plugin;
+
+    /**
+     * The constructor.
+     */
+    public Activator() {
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext
+     * )
+     */
+    @Override
+    public void start(BundleContext context) throws Exception {
+        super.start(context);
+        plugin = this;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext
+     * )
+     */
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        plugin = null;
+        super.stop(context);
+    }
+
+    /**
+     * Returns the shared instance.
+     * 
+     * @return the shared instance
+     */
+    public static Activator getDefault() {
+        return plugin;
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/SwitchYardServiceTaskFeatureContainer.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/SwitchYardServiceTaskFeatureContainer.java
@@ -1,0 +1,155 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.bpmn2;
+
+import org.eclipse.bpmn2.Assignment;
+import org.eclipse.bpmn2.Bpmn2Factory;
+import org.eclipse.bpmn2.DataInput;
+import org.eclipse.bpmn2.DataInputAssociation;
+import org.eclipse.bpmn2.FormalExpression;
+import org.eclipse.bpmn2.Task;
+import org.eclipse.bpmn2.modeler.core.utils.GraphicsUtil;
+import org.eclipse.bpmn2.modeler.core.utils.ModelUtil;
+import org.eclipse.bpmn2.modeler.runtime.jboss.jbpm5.features.JbpmCustomTaskFeatureContainer;
+import org.eclipse.bpmn2.modeler.ui.editor.BPMN2Editor;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.graphiti.features.IAddFeature;
+import org.eclipse.graphiti.features.ICreateFeature;
+import org.eclipse.graphiti.features.IFeatureProvider;
+import org.eclipse.graphiti.features.context.IContext;
+import org.eclipse.graphiti.features.context.ICreateContext;
+import org.eclipse.graphiti.mm.algorithms.Image;
+import org.eclipse.graphiti.mm.algorithms.RoundedRectangle;
+import org.eclipse.graphiti.services.Graphiti;
+import org.eclipse.graphiti.services.IGaService;
+import org.eclipse.wst.common.project.facet.core.FacetedProjectFramework;
+import org.switchyard.tools.ui.editor.ImageProvider;
+import org.switchyard.tools.ui.facets.ISwitchYardFacetConstants;
+
+/**
+ * SwitchYardServiceTaskFeatureContainer
+ * 
+ * <p/>
+ * Custom task container for "SwitchYard Service" tasks. This guy creates and
+ * initializes "SwitchYard Service" tasks.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardServiceTaskFeatureContainer extends JbpmCustomTaskFeatureContainer {
+
+    @Override
+    public ICreateFeature getCreateFeature(IFeatureProvider fp) {
+        return new SwitchYardServiceTaskCreateFeature(fp);
+    }
+
+    @Override
+    public IAddFeature getAddFeature(IFeatureProvider fp) {
+        return new AddCustomTaskFeature(fp) {
+            @Override
+            protected void decorateActivityRectangle(RoundedRectangle rect) {
+                IGaService service = Graphiti.getGaService();
+                Image img = service.createImage(rect, ImageProvider.IMG_16_SWITCHYARD);
+                service.setLocationAndSize(img, 2, 2, GraphicsUtil.TASK_IMAGE_SIZE, GraphicsUtil.TASK_IMAGE_SIZE);
+            }
+        };
+    }
+
+    /**
+     * SwitchYardServiceTaskCreateFeature
+     * 
+     * <p/>
+     * Custom task for creating "SwitchYard Service" tasks.
+     * 
+     * @author Rob Cernich
+     */
+    public class SwitchYardServiceTaskCreateFeature extends JbpmCreateCustomTaskFeature {
+
+        /**
+         * Create a new SwitchYardServiceTaskCreateFeature.
+         * 
+         * @param fp the feature provider.
+         */
+        public SwitchYardServiceTaskCreateFeature(IFeatureProvider fp) {
+            super(fp, customTaskDescriptor.getName(), customTaskDescriptor.getDescription(),
+                    ImageProvider.IMG_16_SWITCHYARD);
+        }
+
+        @Override
+        public boolean isAvailable(IContext context) {
+            return canCreate((ICreateContext) context) && super.isAvailable(context);
+        }
+
+        @Override
+        public boolean canCreate(ICreateContext context) {
+            return super.canCreate(context) && isSwitchYardProject(context);
+        }
+
+        @Override
+        protected Task createFlowElement(ICreateContext context) {
+            Task task = super.createFlowElement(context);
+
+            Resource resource = ((EObject) getBusinessObjectForPictogramElement(context.getTargetContainer()))
+                    .eResource();
+
+            // patch up the input associations. we can't specify input.getId()
+            // in the plugin.xml, so we need to add the assignments manually.
+            for (DataInputAssociation inputAssociation : task.getDataInputAssociations()) {
+                DataInput input = (DataInput) inputAssociation.getTargetRef();
+                if ("ServiceName".equals(input.getName())) {
+                    addInputAssignment(resource, inputAssociation, input, "SomeSwitchYardService");
+                } else if ("ServiceOperationName".equals(input.getName())) {
+                    addInputAssignment(resource, inputAssociation, input, "someServiceOperation");
+                } else if ("MessageContentInName".equals(input.getName())) {
+                    addInputAssignment(resource, inputAssociation, input, "messageContentIn");
+                } else if ("MessageContentOutName".equals(input.getName())) {
+                    addInputAssignment(resource, inputAssociation, input, "messageContentOut");
+                } else if ("messageContentIn".equals(input.getName())) {
+                    // do nothing
+                    inputAssociation.getTargetRef();
+                }
+            }
+
+            return task;
+        }
+
+        private void addInputAssignment(Resource resource, DataInputAssociation inputAssociation, DataInput input,
+                String fromBody) {
+            Assignment assignment = Bpmn2Factory.eINSTANCE.createAssignment();
+            FormalExpression fromExpression = Bpmn2Factory.eINSTANCE.createFormalExpression();
+            FormalExpression toExpression = Bpmn2Factory.eINSTANCE.createFormalExpression();
+
+            ModelUtil.setID(assignment, resource);
+            ModelUtil.setID(fromExpression, resource);
+            ModelUtil.setID(toExpression, resource);
+
+            fromExpression.setBody(fromBody);
+            toExpression.setBody(input.getId());
+
+            assignment.setFrom(fromExpression);
+            assignment.setTo(toExpression);
+
+            inputAssociation.getAssignment().add(assignment);
+        }
+
+    }
+
+    private boolean isSwitchYardProject(ICreateContext context) {
+        try {
+            return FacetedProjectFramework.hasProjectFacet(BPMN2Editor.getActiveEditor().getModelFile().getProject(),
+                    ISwitchYardFacetConstants.SWITCHYARD_FACET_ID);
+        } catch (CoreException e) {
+            return false;
+        }
+
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/SwitchYardServiceTaskPropertiesComposite.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/SwitchYardServiceTaskPropertiesComposite.java
@@ -1,0 +1,56 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.bpmn2;
+
+import org.eclipse.bpmn2.modeler.runtime.jboss.jbpm5.property.JbpmCustomTaskPropertiesComposite;
+import org.eclipse.bpmn2.modeler.ui.property.AbstractBpmn2PropertySection;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * SwitchYardServiceTaskPropertiesComposite
+ * 
+ * <p/>
+ * Custom properties control for "SwitchYard Service" custom tasks.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardServiceTaskPropertiesComposite extends JbpmCustomTaskPropertiesComposite {
+
+    /**
+     * Create a new SwitchYardServiceTaskPropertiesComposite.
+     * 
+     * @param parent the parent composite.
+     * @param style the style bits.
+     */
+    public SwitchYardServiceTaskPropertiesComposite(Composite parent, int style) {
+        super(parent, style);
+    }
+
+    /**
+     * Create a new SwitchYardServiceTaskPropertiesComposite.
+     * 
+     * @param section the containing section.
+     */
+    public SwitchYardServiceTaskPropertiesComposite(AbstractBpmn2PropertySection section) {
+        super(section);
+    }
+
+    @Override
+    public void createBindings(EObject be) {
+        super.createBindings(be);
+
+        // TODO:
+        // custom controls for setting service, operation, input/output param
+        // names, input/output values.
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/SwitchYardServiceTaskPropertySection.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/SwitchYardServiceTaskPropertySection.java
@@ -1,0 +1,67 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.bpmn2;
+
+import java.util.List;
+
+import org.eclipse.bpmn2.Task;
+import org.eclipse.bpmn2.modeler.core.runtime.ModelEnablementDescriptor;
+import org.eclipse.bpmn2.modeler.core.utils.BusinessObjectUtil;
+import org.eclipse.bpmn2.modeler.core.utils.ModelUtil;
+import org.eclipse.bpmn2.modeler.runtime.jboss.jbpm5.property.JbpmCustomTaskPropertySection;
+import org.eclipse.bpmn2.modeler.ui.editor.BPMN2Editor;
+import org.eclipse.bpmn2.modeler.ui.property.AbstractBpmn2PropertiesComposite;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.ui.IWorkbenchPart;
+
+/**
+ * SwitchYardServiceTaskPropertySection
+ * 
+ * <p/>
+ * Custom property section for "SwitchYard Service" tasks.
+ * 
+ * @author Rob Cernich
+ */
+public class SwitchYardServiceTaskPropertySection extends JbpmCustomTaskPropertySection {
+
+    @Override
+    public boolean appliesTo(IWorkbenchPart part, ISelection selection) {
+        // only show this property section if the selected Task is a custom
+        // "SwitchYard Service" task. that is, it has a "taskName" extension
+        // attribute set to "SwitchYard Service".
+        BPMN2Editor editor = (BPMN2Editor) part.getAdapter(BPMN2Editor.class);
+        if (editor != null) {
+            EObject object = BusinessObjectUtil.getBusinessObjectForSelection(selection);
+            ModelEnablementDescriptor modelEnablement = editor.getTargetRuntime().getModelEnablements(object);
+
+            if (object instanceof Task) {
+                if (modelEnablement.isEnabled(object.eClass())) {
+                    List<EStructuralFeature> features = ModelUtil.getAnyAttributes(object);
+                    for (EStructuralFeature f : features) {
+                        if ("taskName".equals(f.getName())
+                                && "SwitchYard Service".equals(((Task) object).getAnyAttribute().get(f, false))) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected AbstractBpmn2PropertiesComposite createSectionRoot() {
+        return new SwitchYardServiceTaskPropertiesComposite(this);
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/ImageProvider.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/ImageProvider.java
@@ -71,6 +71,9 @@ public class ImageProvider extends AbstractImageProvider {
     /** Image for Interface override. **/
     public static final String IMG_16_INTERFACE_OVERRIDE = PREFIX + Interface.class.getSimpleName().toLowerCase() + "plus" + DOT16;
 
+    /** Image for SwitchYard override. **/
+    public static final String IMG_16_SWITCHYARD = PREFIX + "SwitchYard" + DOT16;
+
     @Override
     protected void addAvailableImages() {
         addImageFilePath(IMG_16_COMPOSITE, ICONS_16 + "Composite.gif");
@@ -85,6 +88,7 @@ public class ImageProvider extends AbstractImageProvider {
         addImageFilePath(IMG_16_IMPLEMENTATION_TYPE, ICONS_16 + "ImplementationType.gif");
         addImageFilePath(IMG_16_INTERFACE, ICONS_16 + "interface.gif");
         addImageFilePath(IMG_16_INTERFACE_OVERRIDE, ICONS_16 + "interface_override.gif");
+        addImageFilePath(IMG_16_SWITCHYARD, ICONS_16 + "switchyard_icon_16px.png");
     }
 
 }

--- a/eclipse/plugins/pom.xml
+++ b/eclipse/plugins/pom.xml
@@ -23,6 +23,7 @@
     <module>org.switchyard.tools.core</module>
     <module>org.switchyard.tools.ui</module>
     <module>org.switchyard.tools.ui.editor</module>
+    <module>org.switchyard.tools.ui.bpmn2</module>
   </modules>
 
 </project>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>switchyard-tools-eclipse</artifactId>
   <!--
     Eclipse plugin build versioning (M.m.r.build) is handled through Tycho, so
-    versions like 0.3.0.CR1 and 0.3.0.Final would be handled by Tycho.  The
+    versions like 0.3.0.CR1 and 0.3.0.Final would be handled by Tycho. The
     parent project's version, not being Eclipse specific, should continue to
     evolve along with the rest of the SwitchYard projects.
   -->
@@ -47,6 +47,40 @@
     <repository>
       <id>graphiti-update-site</id>
       <url>http://download.eclipse.org/graphiti/updates/0.8.2/</url>
+      <layout>p2</layout>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+    <!-- The following provide dependencies required by the bpmn2 plugin. -->
+    <repository>
+      <id>bpmn2-model-update-site</id>
+      <url>https://hudson.eclipse.org/hudson/job/bpmn2-nightly/ws/org.eclipse.bpmn2.site/target/site</url>
+      <layout>p2</layout>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+    <repository>
+      <id>bpmn2-editor-update-site</id>
+      <url>http://download.eclipse.org/bpmn2-modeler/site/</url>
+      <layout>p2</layout>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+    <repository>
+      <id>bpel-editor-update-site</id>
+      <url>http://download.eclipse.org/bpel/site/</url>
       <layout>p2</layout>
       <snapshots>
         <enabled>true</enabled>


### PR DESCRIPTION
This plugin extends the bpmn2 editor allowing users to create and edit "SwitchYard Service" custom tasks.

Currently, there is no custom property support (i.e. support for selecting SwitchYard services and operations), but it provides support that is comparable to the plugin for previouse jBPM editor.
