### PR TITLE
SWITCHYARD-896 use clean local repo when running tycho plugin tests

### DIFF
--- a/eclipse/tests/org.switchyard.tools.m2e.tests/plugin_customization.ini
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/plugin_customization.ini
@@ -8,4 +8,6 @@
 # Add "-pluginCustomization plugin_customization.ini" to your Eclipse command line to apply these settings
 #
 org.eclipse.m2e.core/eclipse.m2.updateIndexes=false
+org.eclipse.m2e.core/eclipse.m2.userSettingsFile=./settings.xml
+#org.eclipse.m2e.core/eclipse.m2.debugOutput=true
 org.eclipse.wst.xml.core/honourAllSchemaLocations=false

--- a/eclipse/tests/org.switchyard.tools.m2e.tests/settings.xml
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/settings.xml
@@ -1,6 +1,8 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                       http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!-- points the local repository to the test repository. -->
+  <localRepository>${LOCAL_TEST_REPO}</localRepository>
   <profiles>
     <profile>
       <activation>

--- a/eclipse/tests/org.switchyard.tools.ui.tests/plugin_customization.ini
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/plugin_customization.ini
@@ -8,4 +8,6 @@
 # Add "-pluginCustomization plugin_customization.ini" to your Eclipse command line to apply these settings
 #
 org.eclipse.m2e.core/eclipse.m2.updateIndexes=false
+org.eclipse.m2e.core/eclipse.m2.userSettingsFile=./settings.xml
+#org.eclipse.m2e.core/eclipse.m2.debugOutput=true
 org.eclipse.wst.xml.core/honourAllSchemaLocations=false

--- a/eclipse/tests/org.switchyard.tools.ui.tests/settings.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!-- points the local repository to the test repository. -->
+  <localRepository>${LOCAL_TEST_REPO}</localRepository>
+</settings>

--- a/eclipse/tests/pom.xml
+++ b/eclipse/tests/pom.xml
@@ -32,7 +32,11 @@
           <includes>
             <include>**/*Test.java</include>
           </includes>
-          <argLine>${tycho.test.jvmArgs}</argLine>
+          <!-- LOCAL_TEST_REPO is used by settings.xml in the plugin tests to ensure a clean local repo is
+            used by the tests. This should ensure the tests can resolve any required dependencies. Specific
+            plugin tests must configure a settings.xml. This file can be set automatically by extending AbstractMavenProjectTestCase
+            or through plugin_customization.ini. -->
+          <argLine>${tycho.test.jvmArgs} -DLOCAL_TEST_REPO=${basedir}/../target/repository</argLine>
           <product>org.eclipse.platform.ide</product>
           <appArgLine>-pluginCustomization ${basedir}/plugin_customization.ini -consoleLog</appArgLine>
           <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>


### PR DESCRIPTION
This fixes the test failures by forcing the test instances of Eclipse (i.e. m2e) to use a clean local m2 repository, preventing any weird m2 dependency resolution issues.
