### PR TITLE
SWITCHYARD-936 add p2 repos for EMF and MDT; switch to JBT 3.3 stable p2

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -45,8 +45,8 @@
       </releases>
     </repository>
     <repository>
-      <id>jbosstools-nightly</id>
-      <url>http://download.jboss.org/jbosstools/updates/nightly/core/trunk/</url>
+      <id>jbosstools-stable-indigo</id>
+      <url>http://download.jboss.org/jbosstools/updates/stable/indigo/</url>
       <layout>p2</layout>
       <snapshots>
         <enabled>true</enabled>
@@ -92,6 +92,30 @@
     <repository>
       <id>bpel-editor-update-site</id>
       <url>http://download.eclipse.org/bpel/site/</url>
+      <layout>p2</layout>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+    <!-- provides ...emf.validation.ocl -->
+    <repository>
+      <id>emf-update-site</id>
+      <url>http://download.eclipse.org/modeling/emf/updates/releases/</url>
+      <layout>p2</layout>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+    <!-- provides ..emf.ocl -->
+    <repository>
+      <id>mdt-update-site</id>
+      <url>http://download.eclipse.org/modeling/mdt/updates/</url>
       <layout>p2</layout>
       <snapshots>
         <enabled>true</enabled>


### PR DESCRIPTION
this allows the build to resolve the ocl related dependencies required by the bpmn2 modeler plugins.

as i had problems installing using JBT nightly (which is built on Eclipse 3.8/4.0), i figured it would be good to use the latest stable JBT 3.3 release (which is built on Eclipse 3.7).
