### PR TITLE
SWITCHYARD-988 add support for model validation

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.models.switchyard1_0/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.models.switchyard1_0/plugin.xml
@@ -86,5 +86,29 @@
             class="org.switchyard.tools.models.switchyard1_0.validate.ValidatePackage"
             genModel="model/switchyard_1.0.genmodel"/>
    </extension>
+   <extension
+         point="org.eclipse.emf.ecore.content_parser">
+      <parser
+            class="org.switchyard.tools.models.switchyard1_0.switchyard.util.SwitchyardResourceFactoryImpl"
+            contentTypeIdentifier="org.switchyard.tools.ui.editor.content-type.xml">
+      </parser>
+   </extension>
 
+    <extension
+         point="org.eclipse.core.contenttype.contentTypes">
+      <content-type
+            base-type="org.eclipse.core.runtime.xml"
+            id="org.switchyard.tools.ui.editor.content-type.xml"
+            name="SwitchYard 1.0 XML File"
+            priority="normal">
+         <describer
+               class="org.eclipse.core.runtime.content.XMLRootElementContentDescriber2"
+               plugin="org.eclipse.emf.ecore.xmi">
+            <parameter
+                  name="element"
+                  value="{urn:switchyard-config:switchyard:1.0}*">
+            </parameter>
+         </describer>
+      </content-type>
+ </extension>
 </plugin>

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/META-INF/MANIFEST.MF
@@ -36,10 +36,11 @@ Require-Bundle: org.eclipse.graphiti,
  org.eclipse.core.databinding;bundle-version="1.4.0",
  org.eclipse.core.databinding.observable;bundle-version="1.4.0",
  org.eclipse.core.databinding.property;bundle-version="1.4.0",
- org.eclipse.core.databinding.beans;bundle-version="1.2.100",
+ org.eclipse.core.databinding.beans;bundle-version="1.2.0",
  org.eclipse.emf.databinding;bundle-version="1.2.0",
  org.eclipse.emf.databinding.edit;bundle-version="1.2.0",
- org.eclipse.jface.databinding;bundle-version="1.5.0"
+ org.eclipse.jface.databinding;bundle-version="1.5.0",
+ org.eclipse.emf.edit.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: org.switchyard.tools.ui.editor,

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/plugin.xml
@@ -129,27 +129,11 @@
        </contentTypeBinding>
     </editor>
  </extension>
-    <extension
-         point="org.eclipse.core.contenttype.contentTypes">
-      <content-type
-            base-type="org.eclipse.core.runtime.xml"
-            id="org.switchyard.tools.ui.editor.content-type.xml"
-            name="SwitchYard 1.0 XML File"
-            priority="normal">
-         <describer
-               class="org.eclipse.core.runtime.content.XMLRootElementContentDescriber2"
-               plugin="org.eclipse.emf.ecore.xmi">
-            <parameter
-                  name="element"
-                  value="{urn:switchyard-config:switchyard:1.0}*">
-            </parameter>
-         </describer>
-      </content-type>
- </extension>
 
 	<extension point="org.eclipse.graphiti.ui.imageProviders">
 		<imageProvider class="org.switchyard.tools.ui.editor.ImageProvider"
 			id="org.switchyard.tools.ui.editor.ImageProvider">
 		</imageProvider>
 	</extension>
+
 </plugin>

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/SCADiagramFeatureProvider.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/SCADiagramFeatureProvider.java
@@ -380,27 +380,24 @@ public class SCADiagramFeatureProvider extends DefaultFeatureProvider {
 
     @Override
     public ICustomFeature[] getCustomFeatures(ICustomContext context) {
+        final List<ICustomFeature> features = new ArrayList<ICustomFeature>(3);
         PictogramElement[] pes = context.getPictogramElements();
         if (pes != null && pes.length == 1) {
             Object bo = getBusinessObjectForPictogramElement(pes[0]);
             if (bo instanceof ComponentService) {
-                final List<ICustomFeature> features = new ArrayList<ICustomFeature>(3);
                 features.add(new SCADiagramCustomPromoteServiceFeature(this));
                 if (((ComponentService) bo).getInterface() instanceof JavaInterface) {
                     features.add(new Java2WSDLCustomFeature(this));
                     features.add(new CreateServiceTestCustomFeature(this));
                 }
-//                features.add(new PropertiesDialogFeature(this));
-                return features.toArray(new ICustomFeature[features.size()]);
             } else if (bo instanceof ComponentReference) {
-                return new ICustomFeature[] {new SCADiagramCustomPromoteReferenceFeature(this) }; //, new PropertiesDialogFeature(this) };
+                features.add(new SCADiagramCustomPromoteReferenceFeature(this));
             } else if (bo instanceof Composite) {
-                return new ICustomFeature[] {new AutoLayoutFeature(this) }; //, new PropertiesDialogFeature(this) };
-//            } else if (bo != null) {
-//                return new ICustomFeature[] {new PropertiesDialogFeature(this) };
+                features.add(new AutoLayoutFeature(this));
             }
         }
-        return super.getCustomFeatures(context);
+        features.add(new ValidateModelFeature(this));
+        return features.toArray(new ICustomFeature[features.size()]);
     }
 
     @Override

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/ValidateModelFeature.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/ValidateModelFeature.java
@@ -1,0 +1,121 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.editor.diagram;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.validation.model.EvaluationMode;
+import org.eclipse.emf.validation.model.IConstraintStatus;
+import org.eclipse.emf.validation.service.IBatchValidator;
+import org.eclipse.emf.validation.service.ModelValidationService;
+import org.eclipse.graphiti.features.IFeatureProvider;
+import org.eclipse.graphiti.features.context.ICustomContext;
+import org.eclipse.graphiti.features.custom.AbstractCustomFeature;
+import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.switchyard.tools.ui.validation.ValidationStatusAdapter;
+
+/**
+ * ValidateModelFeature
+ * 
+ * <p/>
+ * Custom feature used for validating the current state of the model.
+ */
+public class ValidateModelFeature extends AbstractCustomFeature {
+
+    /**
+     * Create a new ValidateModelFeature.
+     * 
+     * @param fp the feature provider.
+     */
+    public ValidateModelFeature(IFeatureProvider fp) {
+        super(fp);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Validate the configuration.";
+    }
+
+    @Override
+    public String getName() {
+        return "Validate";
+    }
+
+    @Override
+    public boolean canExecute(ICustomContext context) {
+        return true;
+    }
+
+    @Override
+    public void execute(ICustomContext context) {
+        Set<EObject> selectedBOs = new LinkedHashSet<EObject>();
+        List<? extends PictogramElement> elements = Collections.singletonList(getDiagram());
+        // if (context.getPictogramElements() != null &&
+        // context.getPictogramElements().length > 0) {
+        // elements = Arrays.asList(context.getPictogramElements());
+        // }
+
+        for (PictogramElement element : elements) {
+            Object bo = getBusinessObjectForPictogramElement(element);
+            if (bo instanceof EObject) {
+                selectedBOs.add((EObject) bo);
+            }
+        }
+
+        if (selectedBOs.isEmpty()) {
+            return;
+        }
+
+        IBatchValidator validator = ModelValidationService.getInstance().newValidator(EvaluationMode.BATCH);
+        validator.setOption(IBatchValidator.OPTION_REPORT_SUCCESSES, true);
+
+        Set<EObject> seenTargets = new LinkedHashSet<EObject>();
+        updateValidationStatus(validator.validate(selectedBOs), seenTargets);
+
+        for (EObject target : seenTargets) {
+            PictogramElement pe = getFeatureProvider().getPictogramElementForBusinessObject(target);
+            if (pe != null) {
+                getDiagramEditor().refreshRenderingDecorators(pe);
+            }
+        }
+    }
+
+    @Override
+    public boolean hasDoneChanges() {
+        // we never do any work
+        return false;
+    }
+
+    private void updateValidationStatus(IStatus status, Set<EObject> seenTargets) {
+        if (status.isMultiStatus()) {
+            for (IStatus child : status.getChildren()) {
+                updateValidationStatus(child, seenTargets);
+            }
+        } else if (status instanceof IConstraintStatus) {
+            EObject target = ((IConstraintStatus) status).getTarget();
+            ValidationStatusAdapter statusAdapter = (ValidationStatusAdapter) EcoreUtil.getRegisteredAdapter(target,
+                    ValidationStatusAdapter.class);
+            if (statusAdapter == null) {
+                return;
+            }
+            if (seenTargets.add(target)) {
+                statusAdapter.clearValidationStatus();
+            }
+            statusAdapter.addValidationStatus(status);
+        }
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/connections/SCADiagramCreateComponentServiceLinkFeature.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/connections/SCADiagramCreateComponentServiceLinkFeature.java
@@ -65,7 +65,7 @@ public class SCADiagramCreateComponentServiceLinkFeature extends AbstractCreateC
         if (getAnchorObject(context.getSourceAnchor()) != null) {
             return true;
         }
-        return true;
+        return false;
 
     }
 

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/impl/MultiPageEditor.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/impl/MultiPageEditor.java
@@ -40,6 +40,7 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.ide.IGotoMarker;
 import org.eclipse.ui.part.EditorPart;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.part.MultiPageEditorPart;
@@ -53,7 +54,7 @@ import org.w3c.dom.Node;
  * @author bfitzpat
  * 
  */
-public class MultiPageEditor extends MultiPageEditorPart implements IResourceChangeListener {
+public class MultiPageEditor extends MultiPageEditorPart implements IResourceChangeListener, IGotoMarker {
 
     /** The text editor used in page 0. */
     private SwitchyardSCAEditor _diagramEditor;
@@ -86,9 +87,12 @@ public class MultiPageEditor extends MultiPageEditorPart implements IResourceCha
      * 
      * @param marker Marker to look for
      */
+    @Override
     public void gotoMarker(IMarker marker) {
-        setActivePage(0);
-        IDE.gotoMarker(getEditor(0), marker);
+        if (getActivePage() < 0) {
+            setActivePage(0);
+        }
+        IDE.gotoMarker(getEditor(getActivePage()), marker);
     }
 
     /*

--- a/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
@@ -30,7 +30,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.wst.wsdl;bundle-version="1.2.0",
  org.eclipse.wst.wsdl.ui;bundle-version="1.2.0",
  org.eclipse.wst.xml.core;bundle-version="1.1.0",
- org.eclipse.wst.xml.ui;bundle-version="1.1.0"
+ org.eclipse.wst.xml.ui;bundle-version="1.1.0",
+ org.eclipse.wst.validation,
+ org.eclipse.emf.validation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: org.switchyard.tools.ui,
@@ -42,4 +44,5 @@ Export-Package: org.switchyard.tools.ui,
  org.switchyard.tools.ui.facets,
  org.switchyard.tools.ui.operations,
  org.switchyard.tools.ui.properties,
+ org.switchyard.tools.ui.validation,
  org.switchyard.tools.ui.wizards

--- a/eclipse/plugins/org.switchyard.tools.ui/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui/plugin.xml
@@ -729,5 +729,129 @@
         </adapter>
      </factory>
   </extension>
+  <extension
+        id="projectValidator"
+        name="SwitchYard Project Validator"
+        point="org.eclipse.wst.validation.validatorV2">
+     <validator
+           class="org.switchyard.tools.ui.validation.SwitchYardProjectValidator"
+           markerId="org.switchyard.tools.ui.problemMarker">
+        <include>
+           <rules>
+              <facet
+                    id="switchyard.core">
+              </facet>
+           </rules>
+        </include>
+        <include>
+           <rules>
+              <contentType
+                    exactMatch="true"
+                    id="org.switchyard.tools.ui.editor.content-type.xml">
+              </contentType>
+              <file
+                    caseSensitive="true"
+                    name="switchyard.xml"
+                    type="file">
+              </file>
+           </rules>
+        </include>
+        <exclude>
+           <rules>
+              <file
+                    caseSensitive="true"
+                    name="switchyard.xml.diagram"
+                    type="file">
+              </file>
+           </rules>
+        </exclude>
+     </validator>
+  </extension>
+  <extension
+        id="org.switchyard.tools.ui.problemMarker"
+        name="SwitchYard"
+        point="org.eclipse.core.resources.markers">
+     <persistent
+           value="true">
+     </persistent>
+     <super
+           type="org.eclipse.emf.validation.problem">
+     </super>
+  </extension>
 
+  <!-- Validation Extensions -->
+  <extension
+       point="org.eclipse.emf.validation.constraintBindings">
+    <clientContext
+          default="false"
+          id="org.switchyard.tools.validationContext">
+       <selector
+             class="org.switchyard.tools.ui.validation.SwitchYardClientSelector">
+       </selector>
+    </clientContext>
+    <binding
+          category="org.switchyard.tools.validationCategory/sca"
+          context="org.switchyard.tools.validationContext">
+    </binding>
+  </extension>
+  <extension
+       point="org.eclipse.emf.validation.constraintProviders">
+    <category
+          id="org.switchyard.tools.validationCategory/sca"
+          name="SwitchYard SCA Constraints">
+    </category>
+    <constraintProvider
+          cache="true">
+       <package
+             namespaceUri="http://docs.oasis-open.org/ns/opencsa/sca/200912">
+       </package>
+       <constraints
+             categories="org.switchyard.tools.validationCategory/sca">
+          <constraint
+                class="org.switchyard.tools.ui.validation.UniqueServiceNameConstraint"
+                id="org.switchyard.tools.validation.constraint.service/uniqueness"
+                isEnabledByDefault="true"
+                lang="Java"
+                mode="Batch"
+                name="Unique Service Names"
+                severity="ERROR"
+                statusCode="1">
+             <message>
+                The name, "{0}" must be unique among services, references and component services.
+             </message>
+             <description>
+                All service, reference and component service names must be unique.  (A service name may be identical to the name of the component service it promotes.)
+             </description>
+             <target
+                   class="ComponentService">
+             </target>
+             <target
+                   class="Service">
+             </target>
+             <target
+                   class="Reference">
+             </target>
+          </constraint>
+          <constraint
+                class="org.switchyard.tools.ui.validation.ServiceInterfaceConstraint"
+                id="org.switchyard.tools.validation.constraint.service/interface"
+                isEnabledByDefault="true"
+                lang="Java"
+                mode="Batch"
+                name="Service Interface"
+                severity="ERROR"
+                statusCode="1">
+             <message>
+                No interface is defined for the service/reference.
+             </message>
+             <description>
+                All services and references must define an interface.
+             </description>
+             <target
+                   class="Contract">
+             </target>
+          </constraint>
+       </constraints>
+    </constraintProvider>
+  </extension>
 </plugin>

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ServiceInterfaceConstraint.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ServiceInterfaceConstraint.java
@@ -1,0 +1,53 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.validation;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.validation.AbstractModelConstraint;
+import org.eclipse.emf.validation.EMFEventType;
+import org.eclipse.emf.validation.IValidationContext;
+import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
+
+/**
+ * ServiceInterfaceConstraint
+ * 
+ * <p/>
+ * Validates the interface associated with a service/reference contract.
+ */
+public class ServiceInterfaceConstraint extends AbstractModelConstraint {
+
+    @Override
+    public IStatus validate(IValidationContext ctx) {
+        EObject eObj = ctx.getTarget();
+        EMFEventType eType = ctx.getEventType();
+
+        // In the case of batch mode.
+        if (eType == EMFEventType.NULL) {
+            System.err.println("Batch: " + getClass().getSimpleName() + ": " + eObj);
+            if (eObj instanceof Contract) {
+                return validate(ctx, (Contract) eObj);
+            }
+        } else { // In the case of live mode.
+            System.err.println("Live: " + getClass().getSimpleName() + ": " + eObj + ": " + ctx.getFeatureNewValue());
+        }
+
+        return ctx.createSuccessStatus();
+    }
+
+    private IStatus validate(IValidationContext ctx, Contract contract) {
+        if (contract.getInterface() == null) {
+            return ctx.createFailureStatus();
+        }
+        return ctx.createSuccessStatus();
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/SwitchYardClientSelector.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/SwitchYardClientSelector.java
@@ -1,0 +1,31 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.validation;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.validation.model.IClientSelector;
+import org.switchyard.tools.models.switchyard1_0.switchyard.util.SwitchyardResourceImpl;
+
+/**
+ * SwitchYardClientSelector
+ * 
+ * <p/>
+ * Selector for EMF validation framework.
+ */
+public class SwitchYardClientSelector implements IClientSelector {
+
+    @Override
+    public boolean selects(Object object) {
+        // only available for switchyard files
+        return object instanceof EObject && ((EObject) object).eResource() instanceof SwitchyardResourceImpl;
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/SwitchYardProjectValidator.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/SwitchYardProjectValidator.java
@@ -1,0 +1,133 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.validation;
+
+import java.io.IOException;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EValidator;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.validation.marker.MarkerUtil;
+import org.eclipse.emf.validation.model.EvaluationMode;
+import org.eclipse.emf.validation.model.IConstraintStatus;
+import org.eclipse.emf.validation.service.IBatchValidator;
+import org.eclipse.emf.validation.service.ModelValidationService;
+import org.eclipse.wst.validation.AbstractValidator;
+import org.eclipse.wst.validation.ValidationEvent;
+import org.eclipse.wst.validation.ValidationResult;
+import org.eclipse.wst.validation.ValidationState;
+import org.eclipse.wst.validation.ValidatorMessage;
+import org.switchyard.tools.ui.Activator;
+
+/**
+ * SwitchYardProjectValidator
+ * 
+ * <p/>
+ * WST V2 validator supporting SwitchYard projects.
+ */
+public class SwitchYardProjectValidator extends AbstractValidator {
+
+    /** ID for SwitchYard specific problem markers. */
+    public static final String SWITCHYARD_MARKER_ID = "org.switchyard.tools.ui.problemMarker";
+
+    @Override
+    public ValidationResult validate(ValidationEvent event, ValidationState state, IProgressMonitor monitor) {
+        if ((event.getKind() & IResourceDelta.REMOVED) != 0 || event.getResource().isDerived(IResource.CHECK_ANCESTORS)) {
+            return new ValidationResult();
+        }
+
+        ResourceSet rs = new ResourceSetImpl();
+        Resource resource = rs.createResource(
+                URI.createPlatformResourceURI(event.getResource().getFullPath().toString(), false),
+                "org.switchyard.tools.ui.editor.content-type.xml");
+        try {
+            resource.load(null);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        ValidationResult result = new ValidationResult();
+        if (resource.getContents().isEmpty()) {
+            ValidatorMessage message = ValidatorMessage.create("Invalid switchyard.xml file", event.getResource());
+            message.setType(SWITCHYARD_MARKER_ID);
+            result.add(message);
+        } else {
+            IBatchValidator validator = ModelValidationService.getInstance().newValidator(EvaluationMode.BATCH);
+            processStatus(validator.validate(resource.getContents(), monitor), event.getResource(), result);
+        }
+        return result;
+    }
+
+    private void processStatus(IStatus status, IResource resource, ValidationResult result) {
+        if (status.isMultiStatus()) {
+            for (IStatus child : status.getChildren()) {
+                processStatus(child, resource, result);
+            }
+        } else if (!status.isOK()) {
+            result.add(createValidationMessage(status, resource));
+        }
+    }
+
+    private ValidatorMessage createValidationMessage(IStatus status, IResource resource) {
+        ValidatorMessage message = ValidatorMessage.create(status.getMessage(), resource);
+        switch (status.getSeverity()) {
+        case IStatus.INFO:
+            message.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
+            break;
+        case IStatus.WARNING:
+            message.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+            break;
+        case IStatus.ERROR:
+        case IStatus.CANCEL:
+            message.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+            break;
+        }
+
+        if (status instanceof IConstraintStatus) {
+            IConstraintStatus ics = (IConstraintStatus) status;
+            message.setAttribute(EValidator.URI_ATTRIBUTE, EcoreUtil.getURI(ics.getTarget()).toString());
+            message.setAttribute(MarkerUtil.RULE_ATTRIBUTE, ics.getConstraint().getDescriptor().getId());
+            if (ics.getResultLocus().size() > 0) {
+                StringBuffer relatedUris = new StringBuffer();
+                for (EObject eobject : ics.getResultLocus()) {
+                    relatedUris.append(EcoreUtil.getURI(eobject).toString()).append(" ");
+                }
+                relatedUris.deleteCharAt(relatedUris.length() - 1);
+                message.setAttribute(EValidator.RELATED_URIS_ATTRIBUTE, relatedUris.toString());
+            }
+        }
+
+        message.setType(SWITCHYARD_MARKER_ID);
+
+        return message;
+    }
+
+    @Override
+    public void clean(IProject project, ValidationState state, IProgressMonitor monitor) {
+        super.clean(project, state, monitor);
+        try {
+            project.deleteMarkers(SWITCHYARD_MARKER_ID, false, IProject.DEPTH_INFINITE);
+        } catch (CoreException e) {
+            Activator.getDefault().getLog().log(e.getStatus());
+        }
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/UniqueServiceNameConstraint.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/UniqueServiceNameConstraint.java
@@ -1,0 +1,157 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.validation;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.validation.AbstractModelConstraint;
+import org.eclipse.emf.validation.EMFEventType;
+import org.eclipse.emf.validation.IValidationContext;
+import org.eclipse.soa.sca.sca1_1.model.sca.Component;
+import org.eclipse.soa.sca.sca1_1.model.sca.ComponentReference;
+import org.eclipse.soa.sca.sca1_1.model.sca.ComponentService;
+import org.eclipse.soa.sca.sca1_1.model.sca.Composite;
+import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
+import org.eclipse.soa.sca.sca1_1.model.sca.Reference;
+import org.eclipse.soa.sca.sca1_1.model.sca.Service;
+import org.switchyard.tools.models.switchyard1_0.switchyard.DocumentRoot;
+import org.switchyard.tools.models.switchyard1_0.switchyard.SwitchYardType;
+
+/**
+ * UniqueServiceNameConstraint
+ * 
+ * <p/>
+ * Checks to make sure all component service names are unique.
+ */
+public class UniqueServiceNameConstraint extends AbstractModelConstraint {
+
+    @Override
+    public IStatus validate(IValidationContext ctx) {
+        EObject eObj = ctx.getTarget();
+        EMFEventType eType = ctx.getEventType();
+
+        // In the case of batch mode.
+        if (eType == EMFEventType.NULL) {
+            System.err.println("Batch: " + getClass().getSimpleName() + ": " + eObj);
+            if (eObj instanceof Contract) {
+                return validate(ctx, (Contract) eObj);
+            }
+        } else { // In the case of live mode.
+            System.err.println("Live: " + getClass().getSimpleName() + ": " + eObj + ": " + ctx.getFeatureNewValue());
+        }
+
+        return ctx.createSuccessStatus();
+    }
+
+    private IStatus validate(IValidationContext ctx, Contract contract) {
+        ctx.skipCurrentConstraintFor(contract);
+        if (contract == null || contract instanceof ComponentReference || contract.getName() == null) {
+            return ctx.createSuccessStatus();
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Set<Contract>> names = (Map<String, Set<Contract>>) ctx.getCurrentConstraintData();
+        if (names == null) {
+            names = collectNames(getSwitchYard(ctx.getTarget().eResource()));
+            ctx.putCurrentConstraintData(names);
+        }
+        Set<Contract> contracts = names.get(contract.getName());
+        if (contracts == null) {
+            contracts = new LinkedHashSet<Contract>();
+            names.put(contract.getName(), contracts);
+            return ctx.createSuccessStatus();
+        }
+        Set<Contract> duplicates = new LinkedHashSet<Contract>();
+        int count = 0;
+        for (Contract other : contracts) {
+            duplicates.add(other);
+            if (other == contract || (other instanceof Service && ((Service) other).getPromote() == contract)
+                    || (contract instanceof Service && ((Service) contract).getPromote() == other)) {
+                continue;
+            }
+            ++count;
+        }
+        if (count == 0) {
+            return ctx.createSuccessStatus();
+        }
+        ctx.addResults(duplicates);
+        return ctx.createFailureStatus(contract.getName());
+    }
+
+    private Map<String, Set<Contract>> collectNames(SwitchYardType switchyard) {
+        Map<String, Set<Contract>> names = new HashMap<String, Set<Contract>>();
+        if (switchyard == null || switchyard.getComposite() == null) {
+            return names;
+        }
+        Composite composite = switchyard.getComposite();
+        for (Service service : composite.getService()) {
+            if (service.getName() == null) {
+                continue;
+            }
+            Set<Contract> contracts = new LinkedHashSet<Contract>();
+            contracts.add(service);
+            names.put(service.getName(), contracts);
+        }
+        for (Component component : composite.getComponent()) {
+            for (ComponentService service : component.getService()) {
+                if (service.getName() == null) {
+                    break;
+                }
+                Set<Contract> contracts = names.get(service.getName());
+                if (contracts == null) {
+                    contracts = new LinkedHashSet<Contract>();
+                    contracts.add(service);
+                    names.put(service.getName(), contracts);
+                    break;
+                }
+                int promotedCount = 0;
+                for (Contract existing : contracts) {
+                    if (existing instanceof Service && ((Service) existing).getPromote() == service) {
+                        ++promotedCount;
+                    }
+                }
+                if (promotedCount > 0) {
+                    continue;
+                }
+                contracts.add(service);
+            }
+        }
+        for (Reference reference : composite.getReference()) {
+            if (reference.getName() == null) {
+                continue;
+            }
+            Set<Contract> contracts = names.get(reference.getName());
+            if (contracts == null) {
+                contracts = new LinkedHashSet<Contract>();
+                names.put(reference.getName(), contracts);
+            }
+            contracts.add(reference);
+        }
+        return names;
+    }
+
+    private SwitchYardType getSwitchYard(Resource resource) {
+        if (resource == null || resource.getContents().isEmpty()) {
+            return null;
+        }
+        EObject docroot = resource.getContents().get(0);
+        if (docroot instanceof DocumentRoot) {
+            return ((DocumentRoot) docroot).getSwitchyard();
+        }
+        return null;
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ValidationStatusAdapter.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ValidationStatusAdapter.java
@@ -1,0 +1,95 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.emf.common.notify.impl.AdapterImpl;
+import org.switchyard.tools.ui.Activator;
+
+/**
+ * ValidationStatusAdapter
+ * 
+ * <p/>
+ * An adapter for holding validation status associated with an EObject.
+ */
+public class ValidationStatusAdapter extends AdapterImpl {
+
+    private List<IStatus> _validationStatus = new ArrayList<IStatus>();
+
+    @Override
+    public boolean isAdapterForType(Object type) {
+        return type instanceof Class && getClass().isAssignableFrom((Class<?>) type);
+    }
+
+    /**
+     * @return the validation status for the target object.
+     */
+    public IStatus getValidationStatus() {
+        switch (_validationStatus.size()) {
+        case 0:
+            return Status.OK_STATUS;
+        case 1:
+            return _validationStatus.get(0);
+        }
+        return new MultiStatusWithMessage(_validationStatus.toArray(new IStatus[_validationStatus.size()]));
+    }
+
+    /**
+     * Clears the status associated with the target.
+     */
+    public void clearValidationStatus() {
+        _validationStatus.clear();
+    }
+
+    /**
+     * @param status the status to add/associate with the target.
+     */
+    public void addValidationStatus(IStatus status) {
+        _validationStatus.add(status);
+    }
+
+    private static class MultiStatusWithMessage extends MultiStatus {
+
+        private String _message;
+
+        public MultiStatusWithMessage(IStatus[] newChildren) {
+            super(Activator.PLUGIN_ID, 0, newChildren, "", null);
+        }
+
+        @Override
+        public String getMessage() {
+            if (_message != null) {
+                return _message;
+            }
+            if (getChildren().length == 0) {
+                return super.getMessage();
+            }
+            StringBuffer sb = new StringBuffer();
+            for (IStatus status : getChildren()) {
+                if (status.isOK()) {
+                    continue;
+                }
+                sb.append(" - ").append(status.getMessage()).append('\n');
+            }
+            if (sb.length() > 0) {
+                sb.deleteCharAt(sb.length() - 1);
+            }
+            _message = sb.toString();
+            return _message;
+        }
+
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ValidationStatusAdapterFactory.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ValidationStatusAdapterFactory.java
@@ -1,0 +1,35 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.validation;
+
+import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.emf.common.notify.Notifier;
+import org.eclipse.emf.common.notify.impl.AdapterFactoryImpl;
+
+/**
+ * ValidationStatusAdapterFactory
+ * 
+ * <p/>
+ * Adds a validation status holder to an EObject.
+ */
+public class ValidationStatusAdapterFactory extends AdapterFactoryImpl {
+
+    @Override
+    public boolean isFactoryForType(Object type) {
+        return type instanceof Class && ValidationStatusAdapter.class.isAssignableFrom((Class<?>) type);
+    }
+
+    @Override
+    protected Adapter createAdapter(Notifier target) {
+        return new ValidationStatusAdapter();
+    }
+
+}


### PR DESCRIPTION
added project builder and problem markers
added "validate" operation in editor
added error/warning decorator support to editor
added build listener to update decorators based on problem markers on diagram save
added "goto" support in editor (for problem markers)
added a couple of validators for testing everything out (duplicate service name and service interface not defined)
