### PR TITLE
SWITCHYARD-782 use Java2WSDL when promoting Java service to WSDL service

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.cxf/src/org/switchyard/tools/cxf/Java2WSDLOptions.java
+++ b/eclipse/plugins/org.switchyard.tools.cxf/src/org/switchyard/tools/cxf/Java2WSDLOptions.java
@@ -31,6 +31,7 @@ public class Java2WSDLOptions {
     private String _style = WSDLConstants.DOCUMENT;
     private String _use = WSDLConstants.LITERAL;
     private boolean _useImportedSchema = false;
+    private boolean _wrapped = false;
 
     /**
      * Get the serviceInterface.
@@ -181,4 +182,17 @@ public class Java2WSDLOptions {
         _use = use;
     }
 
+    /**
+     * @return true if WSDL should generated "wrapped" i/o types.
+     */
+    public boolean isWrapped() {
+        return _wrapped;
+    }
+
+    /**
+     * @param wrapped the new "wrapped" value.
+     */
+    public void setWrapped(boolean wrapped) {
+        _wrapped = wrapped;
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/bean/NewBeanComponentWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/bean/NewBeanComponentWizard.java
@@ -12,10 +12,7 @@ package org.switchyard.tools.ui.editor.components.bean;
 
 import java.util.List;
 
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
@@ -29,6 +26,7 @@ import org.eclipse.ui.PlatformUI;
 import org.switchyard.tools.models.switchyard1_0.bean.BeanFactory;
 import org.switchyard.tools.models.switchyard1_0.bean.BeanImplementationType;
 import org.switchyard.tools.ui.JavaUtil;
+import org.switchyard.tools.ui.PlatformResourceAdapterFactory;
 import org.switchyard.tools.ui.editor.diagram.component.IComponentWizard;
 import org.switchyard.tools.ui.editor.util.JavaTypeScanner;
 import org.switchyard.tools.ui.wizards.NewBeanServiceWizard;
@@ -65,16 +63,11 @@ public class NewBeanComponentWizard extends NewBeanServiceWizard implements ICom
         if (container == null || !(getSelection() == null || getSelection().isEmpty())) {
             return;
         }
-        Resource resource = container.eResource();
-        if (resource == null || resource.getURI() == null || !resource.getURI().isPlatformResource()) {
+        IProject project = PlatformResourceAdapterFactory.getContainingProject(container);
+        if (project == null) {
             return;
         }
-        IResource modelFile = ResourcesPlugin.getWorkspace().getRoot()
-                .getFile(new Path(resource.getURI().toPlatformString(true)));
-        if (modelFile == null) {
-            return;
-        }
-        IJavaElement element = JavaUtil.getInitialPackageForProject(JavaCore.create(modelFile.getProject()));
+        IJavaElement element = JavaUtil.getInitialPackageForProject(JavaCore.create(project));
         StructuredSelection selection = element == null ? StructuredSelection.EMPTY : new StructuredSelection(element);
         init(getWorkbench() == null ? PlatformUI.getWorkbench() : getWorkbench(), selection);
     }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/java/NewCamelJavaRouteComponentWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/java/NewCamelJavaRouteComponentWizard.java
@@ -10,12 +10,9 @@
  ************************************************************************************/
 package org.switchyard.tools.ui.editor.components.camel.java;
 
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
@@ -33,6 +30,7 @@ import org.switchyard.tools.models.switchyard1_0.camel.CamelFactory;
 import org.switchyard.tools.models.switchyard1_0.camel.CamelImplementationType;
 import org.switchyard.tools.models.switchyard1_0.camel.JavaDSLType;
 import org.switchyard.tools.ui.JavaUtil;
+import org.switchyard.tools.ui.PlatformResourceAdapterFactory;
 import org.switchyard.tools.ui.editor.diagram.component.IComponentWizard;
 
 /**
@@ -92,16 +90,11 @@ public class NewCamelJavaRouteComponentWizard extends NewClassCreationWizard imp
         if (container == null || !(getSelection() == null || getSelection().isEmpty())) {
             return;
         }
-        Resource resource = container.eResource();
-        if (resource == null || resource.getURI() == null || !resource.getURI().isPlatformResource()) {
+        IProject project = PlatformResourceAdapterFactory.getContainingProject(container);
+        if (project == null) {
             return;
         }
-        IResource modelFile = ResourcesPlugin.getWorkspace().getRoot()
-                .getFile(new Path(resource.getURI().toPlatformString(true)));
-        if (modelFile == null) {
-            return;
-        }
-        IJavaElement element = JavaUtil.getInitialPackageForProject(JavaCore.create(modelFile.getProject()));
+        IJavaElement element = JavaUtil.getInitialPackageForProject(JavaCore.create(project));
         StructuredSelection selection = element == null ? StructuredSelection.EMPTY : new StructuredSelection(element);
         init(getWorkbench() == null ? PlatformUI.getWorkbench() : getWorkbench(), selection);
     }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/java/NewCamelRouteClassWizardPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/java/NewCamelRouteClassWizardPage.java
@@ -90,7 +90,7 @@ public class NewCamelRouteClassWizardPage extends NewClassWizardPage {
         if (serviceInterface == null) {
             return;
         }
-        _serviceInterfaceControl.init(serviceInterface);
+        _serviceInterfaceControl.init(serviceInterface, null);
         _serviceInterfaceControl.setEnabled(false);
         if (getTypeName().length() == 0 || getTypeName().equals(CLASS_NAME_DEFAULT)) {
             setTypeName("" + serviceInterface.getName() + "Route", true);

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/composite/SCADiagramAddCompositeFeature.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/composite/SCADiagramAddCompositeFeature.java
@@ -193,7 +193,7 @@ public class SCADiagramAddCompositeFeature extends AbstractAddShapeFeature {
         GraphicsAlgorithm ga = compositeContainer.getGraphicsAlgorithm();
 
         AddContext context = new AddContext();
-        context.setX(ga.getX() + StyleUtil.COMPOSITE_OUTER_EDGE - StyleUtil.COMPOSITE_PROTRUSION_WIDTH);
+        context.setX(StyleUtil.COMPOSITE_OUTER_EDGE - StyleUtil.COMPOSITE_PROTRUSION_WIDTH);
         context.setY(Math.max(StyleUtil.COMPOSITE_OUTER_EDGE + StyleUtil.COMPOSITE_INNER_EDGE * 2 + ga.getY(),
                 getMaxYForChildShapeCount(featureProvider, compositeContainer, Service.class)));
         context.setTargetContainer(compositeContainer);

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/service/PromoteServiceWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/service/PromoteServiceWizard.java
@@ -1,0 +1,67 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.editor.diagram.service;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.soa.sca.sca1_1.model.sca.ComponentService;
+import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
+import org.switchyard.tools.ui.PlatformResourceAdapterFactory;
+
+/**
+ * PromoteServiceWizard
+ * 
+ * <p/>
+ * Wizard for promoting a component service.
+ */
+public class PromoteServiceWizard extends Wizard {
+
+    private PromoteServiceWizardPage _page;
+
+    /**
+     * Create a new PromoteServiceWizard.
+     */
+    public PromoteServiceWizard() {
+        _page = new PromoteServiceWizardPage();
+        setWindowTitle(_page.getTitle());
+    }
+
+    /**
+     * @param componentService the service being promoted.
+     */
+    public void init(ComponentService componentService) {
+        _page.init(componentService, componentService);
+        IProject project = PlatformResourceAdapterFactory.getContainingProject(componentService);
+        if (project == null) {
+            return;
+        }
+        _page.setJavaProject(JavaCore.create(project));
+    }
+
+    @Override
+    public void addPages() {
+        addPage(_page);
+    }
+
+    @Override
+    public boolean performFinish() {
+        return true;
+    }
+
+    /**
+     * @return the new Contract
+     */
+    public Contract getContract() {
+        return _page.getContract();
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/service/PromoteServiceWizardPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/service/PromoteServiceWizardPage.java
@@ -1,0 +1,32 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.editor.diagram.service;
+
+import org.eclipse.soa.sca.sca1_1.model.sca.ScaPackage;
+import org.switchyard.tools.ui.editor.diagram.shared.NewContractWizardPage;
+
+/**
+ * PromoteServiceWizardPage
+ * 
+ * <p/>
+ * Page for collecting information for the promoted service.
+ */
+public class PromoteServiceWizardPage extends NewContractWizardPage {
+
+    /**
+     * Create a new PromoteServiceWizardPage.
+     */
+    public PromoteServiceWizardPage() {
+        super(PromoteServiceWizardPage.class.getCanonicalName(), "Promote Component Service",
+                "Specify details for the new composite service.", ScaPackage.eINSTANCE.getService());
+    }
+
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/service/SCADiagramCustomPromoteServiceFeature.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/service/SCADiagramCustomPromoteServiceFeature.java
@@ -24,13 +24,11 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.soa.sca.sca1_1.model.sca.ComponentService;
 import org.eclipse.soa.sca.sca1_1.model.sca.Composite;
-import org.eclipse.soa.sca.sca1_1.model.sca.ScaPackage;
 import org.eclipse.soa.sca.sca1_1.model.sca.Service;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.switchyard.tools.ui.editor.ImageProvider;
 import org.switchyard.tools.ui.editor.diagram.composite.SCADiagramAddCompositeFeature;
-import org.switchyard.tools.ui.editor.diagram.shared.BaseNewContractWizard;
 import org.switchyard.tools.ui.editor.model.merge.MergedModelUtil;
 
 /**
@@ -63,8 +61,7 @@ public class SCADiagramCustomPromoteServiceFeature extends AbstractCustomFeature
 
     private void createService(ComponentService componentService, Shape componentServiceShape) {
         Service newService = null;
-        BaseNewContractWizard wizard = new BaseNewContractWizard("Promote Component Service",
-                "Specify details for the new composite service.", ScaPackage.eINSTANCE.getService());
+        PromoteServiceWizard wizard = new PromoteServiceWizard();
         wizard.init(componentService);
         Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
         WizardDialog wizDialog = new WizardDialog(shell, wizard);

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/BaseNewContractWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/BaseNewContractWizard.java
@@ -10,15 +10,13 @@
  ************************************************************************************/
 package org.switchyard.tools.ui.editor.diagram.shared;
 
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
+import org.switchyard.tools.ui.PlatformResourceAdapterFactory;
 
 /**
  * BaseNewContractWizard
@@ -54,16 +52,11 @@ public class BaseNewContractWizard extends Wizard {
         if (container == null) {
             return;
         }
-        Resource resource = container.eResource();
-        if (resource == null || resource.getURI() == null || !resource.getURI().isPlatformResource()) {
+        IProject project = PlatformResourceAdapterFactory.getContainingProject(container);
+        if (project == null) {
             return;
         }
-        IResource modelFile = ResourcesPlugin.getWorkspace().getRoot()
-                .getFile(new Path(resource.getURI().toPlatformString(true)));
-        if (modelFile == null) {
-            return;
-        }
-        _page.setJavaProject(JavaCore.create(modelFile.getProject()));
+        _page.setJavaProject(JavaCore.create(project));
     }
 
     /**
@@ -72,9 +65,10 @@ public class BaseNewContractWizard extends Wizard {
      * 
      * @param contract initialize control with details from an existing
      *            contract.
+     * @param related the related contract (e.g. when promoting a service)
      */
-    public void init(Contract contract) {
-        _page.init(contract);
+    public void init(Contract contract, Contract related) {
+        _page.init(contract, related);
         init((EObject) contract);
     }
 

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/BaseNewServiceFileWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/BaseNewServiceFileWizard.java
@@ -17,13 +17,12 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -48,6 +47,7 @@ import org.eclipse.ui.dialogs.WizardNewFileCreationPage;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.wizards.newresource.BasicNewFileResourceWizard;
 import org.switchyard.tools.ui.JavaUtil;
+import org.switchyard.tools.ui.PlatformResourceAdapterFactory;
 import org.switchyard.tools.ui.common.ContractControl;
 import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
 import org.switchyard.tools.ui.editor.Activator;
@@ -160,17 +160,12 @@ public abstract class BaseNewServiceFileWizard extends BasicNewFileResourceWizar
         if (container == null || !(getSelection() == null || getSelection().isEmpty())) {
             return;
         }
-        Resource resource = container.eResource();
-        if (resource == null || resource.getURI() == null || !resource.getURI().isPlatformResource()) {
+        IProject project = PlatformResourceAdapterFactory.getContainingProject(container);
+        if (project == null) {
             return;
         }
-        IResource modelFile = ResourcesPlugin.getWorkspace().getRoot()
-                .getFile(new Path(resource.getURI().toPlatformString(true)));
-        if (modelFile == null) {
-            return;
-        }
-        IResource folder = JavaUtil.getFirstResourceRoot(JavaCore.create(modelFile.getProject()));
-        StructuredSelection selection = new StructuredSelection(folder == null ? modelFile.getParent() : folder);
+        IResource folder = JavaUtil.getFirstResourceRoot(JavaCore.create(project));
+        StructuredSelection selection = new StructuredSelection(folder == null ? project : folder);
         init(getWorkbench() == null ? PlatformUI.getWorkbench() : getWorkbench(), selection);
     }
 
@@ -290,7 +285,7 @@ public abstract class BaseNewServiceFileWizard extends BasicNewFileResourceWizar
             });
 
             if (_service != null) {
-                _contractControl.init(_service);
+                _contractControl.init(_service, null);
                 _contractControl.setEnabled(false);
             }
             // get the new instance

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/NewContractWizardPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/NewContractWizardPage.java
@@ -49,7 +49,8 @@ public class NewContractWizardPage extends WizardPage {
     public NewContractWizardPage(String pageName, String title, String description, EClass contractType) {
         super(pageName, title, null);
         setDescription(description);
-        _contractControl = new ContractControl(contractType, null, EnumSet.of(InterfaceType.Java, InterfaceType.WSDL, InterfaceType.ESB));
+        _contractControl = new ContractControl(contractType, null, EnumSet.of(InterfaceType.Java, InterfaceType.WSDL,
+                InterfaceType.ESB));
     }
 
     @Override
@@ -77,9 +78,10 @@ public class NewContractWizardPage extends WizardPage {
      * 
      * @param contract initialize control with details from an existing
      *            contract.
+     * @param related the related contract (e.g. when promoting a service)
      */
-    public void init(Contract contract) {
-        _contractControl.init(contract);
+    public void init(Contract contract, Contract related) {
+        _contractControl.init(contract, related);
     }
 
     /**

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/model/merge/AbstractMergedModelAdapter.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/model/merge/AbstractMergedModelAdapter.java
@@ -356,7 +356,6 @@ public abstract class AbstractMergedModelAdapter implements Adapter {
                 if (copy == null) {
                     copy = (EObject) key;
                 }
-                put((EObject) key, copy);
             }
             return copy;
         }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/property/InterfaceControlPropertiesSection.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/property/InterfaceControlPropertiesSection.java
@@ -110,7 +110,7 @@ public class InterfaceControlPropertiesSection extends GFPropertySection impleme
                 _service = contract;
                 
                 // init controls
-                _interfaceControl.init(_interface);
+                _interfaceControl.init(_interface, null);
             }
         }
         _inUpdate = false;

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ContractControl.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ContractControl.java
@@ -157,8 +157,9 @@ public class ContractControl implements ISelectionProvider {
      * 
      * @param contract initialize control with details from an existing
      *            contract.
+     * @param related the contract related to the contract being edited
      */
-    public void init(Contract contract) {
+    public void init(Contract contract, Contract related) {
         if (contract == null) {
             return;
         }
@@ -167,7 +168,7 @@ public class ContractControl implements ISelectionProvider {
         } else if (contract.getName() != null) {
             _serviceNameText.setText(contract.getName());
         }
-        _interfaceControl.init(contract.getInterface());
+        _interfaceControl.init(contract.getInterface(), related == null ? null : related.getInterface());
     }
 
     /**
@@ -179,7 +180,7 @@ public class ContractControl implements ISelectionProvider {
         if (intf == null) {
             return;
         }
-        _interfaceControl.init(intf);
+        _interfaceControl.init(intf, null);
     }
 
     /**

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/IInterfaceControlAdapter.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/IInterfaceControlAdapter.java
@@ -36,6 +36,11 @@ public interface IInterfaceControlAdapter {
     public void init(Interface intf);
 
     /**
+     * @param related the related interface, if any.
+     */
+    public void setRelatedInterface(Interface related);
+
+    /**
      * The "browse" button on the control has been pressed. Implementations
      * should implement appropriate behavior based on the type they are
      * supporting (e.g. select type for JavaInterface).
@@ -54,10 +59,12 @@ public interface IInterfaceControlAdapter {
      * 
      * @param shell the parent shell
      * @param project the containing project (may be used to reduce scope)
+     * @param useRelated use any specified related interface when creating a new
+     *            interface.
      * 
      * @return true if the data associated with this adapter has changed.
      */
-    public boolean open(Shell shell, IJavaProject project);
+    public boolean open(Shell shell, IJavaProject project, boolean useRelated);
 
     /**
      * @return the text that should be displayed for the interface type (e.g.

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/ESBInterfaceControlAdapter.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/ESBInterfaceControlAdapter.java
@@ -48,6 +48,10 @@ public class ESBInterfaceControlAdapter implements IInterfaceControlAdapter {
     }
 
     @Override
+    public void setRelatedInterface(Interface related) {
+    }
+
+    @Override
     public void init(Interface intf) {
         if (intf instanceof EsbInterface) {
             final EsbInterface esbIntfc = (EsbInterface) intf;
@@ -81,7 +85,7 @@ public class ESBInterfaceControlAdapter implements IInterfaceControlAdapter {
     }
 
     @Override
-    public boolean open(Shell shell, IJavaProject project) {
+    public boolean open(Shell shell, IJavaProject project, boolean useRelated) {
         return browse(shell, project);
     }
 

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/JavaInterfaceControlAdapter.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/JavaInterfaceControlAdapter.java
@@ -61,6 +61,11 @@ public class JavaInterfaceControlAdapter implements IInterfaceControlAdapter {
     }
 
     @Override
+    public void setRelatedInterface(Interface related) {
+        // TODO: store related away for when we support WSDL->Java
+    }
+
+    @Override
     public void init(Interface intf) {
         final String typeString = intf == null ? null : ((JavaInterface) intf).getInterface();
         _interface.setInterface(typeString);
@@ -93,7 +98,8 @@ public class JavaInterfaceControlAdapter implements IInterfaceControlAdapter {
     }
 
     @Override
-    public boolean open(Shell shell, IJavaProject project) {
+    public boolean open(Shell shell, IJavaProject project, boolean useRelated) {
+        // TODO: if useRelated....
         IJavaElement initialJavaElement = JavaUtil.getInitialPackageForProject(project);
         IStructuredSelection selectionToPass;
         if (initialJavaElement == null) {

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/Java2WSDLWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/Java2WSDLWizard.java
@@ -14,6 +14,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -63,6 +64,7 @@ public class Java2WSDLWizard extends BasicNewResourceWizard {
      */
     public Java2WSDLWizard() {
         setNeedsProgressMonitor(true);
+        setWindowTitle("Java2WSDL");
     }
 
     /**
@@ -97,6 +99,7 @@ public class Java2WSDLWizard extends BasicNewResourceWizard {
         };
         _filePage.setFileExtension("wsdl");
         _filePage.setTitle("New WSDL File");
+        _filePage.setDescription("Specify the location of the new WSDL file.");
         setFilePageDefaults();
         addPage(_filePage);
 
@@ -112,6 +115,8 @@ public class Java2WSDLWizard extends BasicNewResourceWizard {
         options.setServiceInterface(_optionsPage.getServiceInterface());
         options.setTargetNamespace(_optionsPage.getTargetNamespace());
         options.setUseImportedSchema(_optionsPage.isUseImportedSchema());
+        options.setServiceName(_optionsPage.getServiceName());
+        options.setWrapped(_optionsPage.isUseWrappedMessages());
 
         _wsdlFile = ResourcesPlugin.getWorkspace().getRoot()
                 .getFile(_filePage.getContainerFullPath().append(_filePage.getFileName()));
@@ -242,6 +247,12 @@ public class Java2WSDLWizard extends BasicNewResourceWizard {
             return name;
         }
         return name.substring(0, dot);
+    }
+
+    protected IProject getTargetProject() {
+        final IResource resource = ResourcesPlugin.getWorkspace().getRoot()
+                .findMember(_filePage.getContainerFullPath());
+        return resource == null ? null : resource.getProject();
     }
 
 }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewBeanServiceClassWizardPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewBeanServiceClassWizardPage.java
@@ -125,7 +125,7 @@ public class NewBeanServiceClassWizardPage extends NewTypeWizardPage {
         if (serviceInterface == null) {
             return;
         }
-        _serviceInterfaceControl.init(serviceInterface);
+        _serviceInterfaceControl.init(serviceInterface, null);
         _serviceInterfaceControl.setEnabled(false);
 
         serviceInterfaceChanged();

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewServiceTestClassWizardPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/wizards/NewServiceTestClassWizardPage.java
@@ -609,7 +609,7 @@ public class NewServiceTestClassWizardPage extends NewTypeWizardPage {
         } else if (contract.getInterface() == null) {
             _serviceInterfaceStatus.setError("Selected service does not define any interface.");
         }
-        _interfaceControl.init(contract == null ? null : contract.getInterface());
+        _interfaceControl.init(contract == null ? null : contract.getInterface(), null);
 
         String newName = createDefaultClassName();
         if (updateDefault(_oldTypeName, newName, getTypeName())) {


### PR DESCRIPTION
Also fixes:
- Add support for generated "wrapped" WSDL message types
- SWITCHYARD-925 better default for endpoint URI
- CCME in new merged model update code
- Location problem when adding promoted service figure
