### PR TITLE
SWITCHYARD-1107 use local build repo when running plugin tests

### DIFF
--- a/eclipse/tests/org.switchyard.tools.m2e.tests/settings.xml
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/settings.xml
@@ -24,4 +24,7 @@
       </repositories>
     </profile>
   </profiles>
+
+  <!-- points the local repository to the test repository. -->
+  <localRepository>${LOCAL_TEST_REPO}</localRepository>
 </settings>

--- a/eclipse/tests/org.switchyard.tools.ui.editor.tests.swt/settings.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.editor.tests.swt/settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!-- points the local repository to the test repository. -->
+  <localRepository>${LOCAL_TEST_REPO}</localRepository>
+</settings>

--- a/eclipse/tests/org.switchyard.tools.ui.tests/settings.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!-- points the local repository to the test repository. -->
+  <localRepository>${LOCAL_TEST_REPO}</localRepository>
+</settings>

--- a/eclipse/tests/pom.xml
+++ b/eclipse/tests/pom.xml
@@ -32,7 +32,11 @@
           <includes>
             <include>**/*Test.java</include>
           </includes>
-          <argLine>${tycho.test.jvmArgs} -Dusage_reporting_enabled=false</argLine>
+              <!-- LOCAL_TEST_REPO is used by settings.xml in the plugin tests to ensure a clean local repo is
+                used by the tests. This should ensure the tests can resolve any required dependencies. Specific
+                plugin tests must configure a settings.xml. This file can be set automatically by extending AbstractMavenProjectTestCase
+                or through plugin_customization.ini. -->
+          <argLine>${tycho.test.jvmArgs} -Dusage_reporting_enabled=false -DLOCAL_TEST_REPO=${settings.localRepository}</argLine>
           <product>org.eclipse.platform.ide</product>
           <appArgLine>-pluginCustomization ${basedir}/plugin_customization.ini -consoleLog</appArgLine>
           <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>


### PR DESCRIPTION
forces the tests to use workspace/.repository as the local maven repo when running tests (as opposed to /home/jenkins/...).
