### PR TITLE
SWITCHYARD-1065 - Creating new editor tab for Domain settings

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.editor/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/plugin.xml
@@ -39,12 +39,6 @@
               label="Bindings">
         </propertyTab>
         <propertyTab
-              afterTab="switchyard.application.tab"
-              category="SwitchyardSCA"
-              id="switchyard.application.tab"
-              label="Application">
-        </propertyTab>
-        <propertyTab
               afterTab="switchyard.binding.tab"
               category="SwitchyardSCA"
               id="switchyard.interface.tab"
@@ -104,11 +98,6 @@
 	         class="org.switchyard.tools.ui.editor.property.SwitchyardSCAPropertiesMainSection"
 	         filter="org.switchyard.tools.ui.editor.property.SwitchyardSCAPropertiesMainFilter"
 	         id="switchyard.main.tab.names">
-	        </propertySection>
-	        <propertySection tab="switchyard.application.tab"            
-	         class="org.switchyard.tools.ui.editor.property.ApplicationPropertySection"
-	         filter="org.switchyard.tools.ui.editor.property.ApplicationPropertyFilter"
-	         id="switchyard.application.tab">
 	        </propertySection>
          <propertySection
                class="org.switchyard.tools.ui.editor.property.SwitchyardSCAPropertiesBindingsSection"

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/DomainPropertyInputDialog.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/DomainPropertyInputDialog.java
@@ -1,0 +1,163 @@
+/*************************************************************************************
+ * Copyright (c) 2012 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.editor.diagram.shared;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.KeyListener;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * @author bfitzpat
+ * 
+ */
+public class DomainPropertyInputDialog extends TitleAreaDialog {
+
+    private Text _propertyNameText;
+    private Text _propertyValueText;
+
+    private String _propertyName = null;
+    private String _propertyValue = null;
+
+    /**
+     * ESBInterfaceInputDialog constructor.
+     * 
+     * @param parent the parent
+     */
+    public DomainPropertyInputDialog(Shell parent) {
+        super(parent);
+    }
+
+    @Override
+    protected Control createDialogArea(Composite parent) {
+        setTitle("New Property Details");
+        setMessage("Specify a name and value for the new property.");
+        getShell().setText("Domain Property");
+
+        Composite area = new Composite(parent, SWT.NULL);
+        GridLayout gridLayout = new GridLayout(2, false);
+        area.setLayout(gridLayout);
+        area.setLayoutData(new GridData(GridData.FILL_BOTH));
+        _propertyNameText = createLabelAndText(area, "Name*");
+        if (_propertyName != null && !_propertyName.trim().isEmpty()) {
+            _propertyNameText.setText(_propertyName);
+        }
+        _propertyNameText.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent e) {
+                _propertyName = _propertyNameText.getText().trim();
+            }
+        });
+        _propertyValueText = createLabelAndText(area, "Value*");
+        if (_propertyValue != null && !_propertyValue.trim().isEmpty()) {
+            _propertyValueText.setText(_propertyValue);
+        }
+        _propertyValueText.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent e) {
+                _propertyValue = _propertyValueText.getText().trim();
+            }
+        });
+
+        return area;
+    }
+    
+    protected Control createButtonBar(Composite parent) {
+        Control rtnControl = super.createButtonBar(parent);
+        getButton(IDialogConstants.OK_ID).setEnabled(validate());
+        setErrorMessage(null);
+        return rtnControl;
+    }
+
+    /**
+     * @param parent parent composite
+     * @param label string to put in label
+     * @return reference to created Text control
+     */
+    protected Text createLabelAndText(Composite parent, String label) {
+        new Label(parent, SWT.NONE).setText(label);
+        Text newText = new Text(parent, SWT.BORDER);
+        newText.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false));
+        newText.addFocusListener(new FocusListener() {
+            @Override
+            public void focusGained(FocusEvent e) {
+                // ignore
+            }
+
+            @Override
+            public void focusLost(FocusEvent e) {
+                getButton(IDialogConstants.OK_ID).setEnabled(validate());
+            }
+        });
+        newText.addKeyListener(new KeyListener() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                // ignore
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+                getButton(IDialogConstants.OK_ID).setEnabled(validate());
+            }
+        });
+        return newText;
+    }
+
+    protected boolean validate() {
+        setErrorMessage(null);
+        if (_propertyNameText.getText().trim().isEmpty()) {
+            setErrorMessage("Please specify a name for the new property.");
+        } else if (_propertyValueText.getText().trim().isEmpty()) {
+            setErrorMessage("Please specify a value for the new property.");
+        }
+        return (getErrorMessage() == null);
+    }
+
+    /**
+     * @return input type
+     */
+    public String getPropertyName() {
+        return _propertyName;
+    }
+
+    /**
+     * @return output type
+     */
+    public String getPropertyValue() {
+        return _propertyValue;
+    }
+
+    /**
+     * @param name prop name
+     */
+    public void setPropertyName(String name) {
+        _propertyName = name;
+    }
+
+    /**
+     * @param value prop value
+     */
+    public void setPropertyValue(String value) {
+        _propertyValue = value;
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/DomainPropertyTable.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/DomainPropertyTable.java
@@ -1,0 +1,455 @@
+/******************************************************************************* 
+ * Copyright (c) 2012 Red Hat, Inc. 
+ *  All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ *
+ * @author bfitzpat
+ ******************************************************************************/
+package org.switchyard.tools.ui.editor.diagram.shared;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import org.eclipse.core.runtime.ListenerList;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.ICellModifier;
+import org.eclipse.jface.viewers.ILabelProviderListener;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITableLabelProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.TextCellEditor;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.TreeColumn;
+import org.eclipse.swt.widgets.TreeItem;
+import org.switchyard.tools.models.switchyard1_0.switchyard.DomainType;
+import org.switchyard.tools.models.switchyard1_0.switchyard.PropertyType;
+import org.switchyard.tools.ui.editor.impl.SwitchyardSCAEditor;
+
+/**
+ * @author bfitzpat
+ * 
+ */
+public abstract class DomainPropertyTable extends Composite implements ICellModifier {
+
+    private class PropertyTypeTreeContentProvider implements ITreeContentProvider {
+        private EList<PropertyType> _properties;
+
+        @Override
+        public void dispose() {
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+            if (newInput instanceof EList<?>) {
+                _properties = (EList<PropertyType>) newInput;
+            }
+        }
+
+        @Override
+        public Object[] getElements(Object inputElement) {
+            if (inputElement instanceof EList<?>) {
+                return _properties.toArray();
+            }
+            return null;
+        }
+
+        @Override
+        public Object[] getChildren(Object parentElement) {
+            if (parentElement instanceof PropertyType[]) {
+                return new Object[] {_properties.toArray() };
+            }
+            return null;
+        }
+
+        @Override
+        public Object getParent(Object element) {
+            if (element instanceof PropertyType) {
+                return ((PropertyType) element).eContainer();
+            }
+            return null;
+        }
+
+        @Override
+        public boolean hasChildren(Object element) {
+            if (element instanceof EList<?>) {
+                return ((EList<?>) element).size() > 0;
+            }
+            return false;
+        }
+    }
+
+    private class PropertyTypeTreeLabelProvider implements ITableLabelProvider {
+        @Override
+        public void addListener(ILabelProviderListener listener) {
+        }
+
+        @Override
+        public void dispose() {
+        }
+
+        @Override
+        public boolean isLabelProperty(Object element, String property) {
+            if (element instanceof PropertyType && property.equalsIgnoreCase(NAME_COLUMN)) {
+                return true;
+            } else if (element instanceof PropertyType && property.equalsIgnoreCase(VALUE_COLUMN)) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public void removeListener(ILabelProviderListener listener) {
+        }
+
+        @Override
+        public Image getColumnImage(Object element, int columnIndex) {
+            return null;
+        }
+
+        @Override
+        public String getColumnText(Object element, int columnIndex) {
+            if (element instanceof PropertyType && columnIndex == 0) {
+                return ((PropertyType) element).getName();
+            } else if (element instanceof PropertyType && columnIndex == 1) {
+                PropertyType tp = (PropertyType) element;
+                return (String) tp.getValue();
+            }
+            return null;
+        }
+    }
+
+    private TreeViewer _propertyTreeTable;
+    
+    /**
+     *  Name column.
+     */
+    public static final String NAME_COLUMN = "name";
+    
+    /**
+     * Value column. 
+     */
+    public static final String VALUE_COLUMN = "value";
+    private static final String[] TREE_COLUMNS = new String[] {NAME_COLUMN, VALUE_COLUMN };
+
+    private Button _mAddButton;
+    private Button _mRemoveButton;
+    private boolean _isReadOnly = false;
+    private EObject _targetObj = null;
+    private String _mWarning = null;
+    private ListenerList _changeListeners;
+
+    /**
+     * Constructor.
+     * 
+     * @param parent Composite parent
+     * @param style any SWT style bits to pass along
+     */
+    public DomainPropertyTable(Composite parent, int style) {
+        this(parent, style, false);
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param parent composite parent
+     * @param style any SWT style bits
+     * @param isReadOnly boolean flag
+     */
+    public DomainPropertyTable(Composite parent, int style, boolean isReadOnly) {
+        super(parent, style);
+        this._isReadOnly = isReadOnly;
+        this._changeListeners = new ListenerList();
+
+        int additionalStyles = SWT.NONE;
+        if (isReadOnly) {
+            additionalStyles = SWT.READ_ONLY;
+        }
+
+        final GridLayout gridLayout = new GridLayout();
+        gridLayout.marginWidth = 0;
+        gridLayout.marginHeight = 0;
+        gridLayout.numColumns = 2;
+        setLayout(gridLayout);
+
+        _propertyTreeTable = new TreeViewer(this, SWT.BORDER | SWT.WRAP | SWT.V_SCROLL | SWT.FULL_SELECTION
+                | additionalStyles);
+        this._propertyTreeTable.setAutoExpandLevel(TreeViewer.ALL_LEVELS);
+        GridData gd11 = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 5);
+        gd11.heightHint = 100;
+        _propertyTreeTable.getTree().setLayoutData(gd11);
+        _propertyTreeTable.getTree().setHeaderVisible(true);
+        TreeColumn nameColumn = new TreeColumn(_propertyTreeTable.getTree(), SWT.LEFT);
+        nameColumn.setText("Name");
+        nameColumn.setWidth(200);
+        TreeColumn valueColumn = new TreeColumn(_propertyTreeTable.getTree(), SWT.LEFT);
+        valueColumn.setText("Value");
+        valueColumn.setWidth(200);
+
+        _propertyTreeTable.setColumnProperties(TREE_COLUMNS);
+
+        _propertyTreeTable.setLabelProvider(new PropertyTypeTreeLabelProvider());
+
+        _propertyTreeTable.setContentProvider(new PropertyTypeTreeContentProvider());
+
+        _propertyTreeTable.setCellModifier(this);
+        _propertyTreeTable.setCellEditors(new CellEditor[] {null, new TextCellEditor(_propertyTreeTable.getTree()),
+                null });
+
+        this._mAddButton = new Button(this, SWT.NONE);
+        this._mAddButton.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL));
+        this._mAddButton.setText("Add");
+        this._mAddButton.addSelectionListener(new SelectionAdapter() {
+
+            public void widgetSelected(SelectionEvent e) {
+                addPropertyTypeToList();
+                if (_propertyTreeTable.getInput() == null) {
+                    DomainType domain = (DomainType) _targetObj;
+                    _propertyTreeTable.setInput(domain.getProperties());
+                }
+                _propertyTreeTable.refresh();
+                fireChangedEvent(e.getSource());
+            }
+        });
+
+        this._mAddButton.setEnabled(false);
+
+        _propertyTreeTable.getTree().addSelectionListener(new SelectionAdapter() {
+
+            public void widgetSelected(SelectionEvent e) {
+                updatePropertyTypeButtons();
+            }
+        });
+
+        this._mRemoveButton = new Button(this, SWT.NONE);
+        this._mRemoveButton.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL));
+        this._mRemoveButton.setText("Remove");
+        this._mRemoveButton.setEnabled(false);
+        this._mRemoveButton.addSelectionListener(new SelectionAdapter() {
+
+            public void widgetSelected(SelectionEvent e) {
+                removeFromList();
+                _propertyTreeTable.refresh();
+                fireChangedEvent(e.getSource());
+            }
+        });
+
+        updatePropertyTypeButtons();
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+    }
+
+    @Override
+    protected void checkSubclass() {
+        // empty
+    }
+
+    /**
+     * Add a new property to the list
+     */
+    protected abstract void addPropertyTypeToList();
+
+    /**
+     * Remove a property from the list
+     */
+    protected abstract void removeFromList();
+
+    /**
+     * Return the current selection.
+     * 
+     * @return String list
+     */
+    @SuppressWarnings("unchecked")
+    public EList<PropertyType> getSelection() {
+        if (_propertyTreeTable != null && _propertyTreeTable.getInput() != null) {
+            return (EList<PropertyType>) _propertyTreeTable.getInput();
+        }
+        return null;
+    }
+    
+    public PropertyType getTableSelection() {
+        if (_propertyTreeTable != null && !_propertyTreeTable.getSelection().isEmpty()) {
+            IStructuredSelection ssel = (IStructuredSelection) _propertyTreeTable.getSelection();
+            if (ssel.getFirstElement() instanceof PropertyType) {
+                return (PropertyType) ssel.getFirstElement();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Update button state based on what's selected.
+     */
+    public void updatePropertyTypeButtons() {
+        if (_isReadOnly) {
+            this._mAddButton.setEnabled(false);
+            this._mRemoveButton.setEnabled(false);
+
+        } else {
+            this._mAddButton.setEnabled(true);
+            if (getSelection() != null) {
+                _mRemoveButton.setEnabled(true);
+            }
+        }
+    }
+
+    /**
+     * @param properties incoming property list
+     */
+    public void setSelection(EList<PropertyType> properties) {
+        _propertyTreeTable.setInput(properties);
+        updatePropertyTypeButtons();
+    }
+
+    /**
+     * @return warning string
+     */
+    public String getWarning() {
+        return this._mWarning;
+    }
+
+    /**
+     * If we changed, fire a changed event.
+     * 
+     * @param source
+     */
+    protected void fireChangedEvent(Object source) {
+        ChangeEvent e = new ChangeEvent(source);
+        // inform any listeners of the resize event
+        Object[] listeners = this._changeListeners.getListeners();
+        for (int i = 0; i < listeners.length; ++i) {
+            ((ChangeListener) listeners[i]).stateChanged(e);
+        }
+    }
+
+    /**
+     * Add a change listener.
+     * 
+     * @param listener new listener
+     */
+    public void addChangeListener(ChangeListener listener) {
+        this._changeListeners.add(listener);
+    }
+
+    /**
+     * Remove a change listener.
+     * 
+     * @param listener old listener
+     */
+    public void removeChangeListener(ChangeListener listener) {
+        this._changeListeners.remove(listener);
+    }
+
+    /**
+     * @param target Passed in what we're dropping on
+     */
+    public void setTargetObject(EObject target) {
+        this._targetObj = target;
+    }
+
+    protected EObject getTargetObject() {
+        return this._targetObj;
+    }
+    
+    protected void setFeatureValue(EObject eObject, String featureId, Object value) {
+        EClass eClass = eObject.eClass();
+        for (int i = 0, size = eClass.getFeatureCount(); i < size; ++i) {
+            EStructuralFeature eStructuralFeature = eClass.getEStructuralFeature(i);
+            if (eStructuralFeature.isChangeable()) {
+                if (eStructuralFeature.getName().equalsIgnoreCase(featureId)) {
+                    eObject.eSet(eStructuralFeature, value);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param element Object being modified
+     * @param property PropertyType being modified
+     * @return boolean flag
+     * @see org.eclipse.jface.viewers.ICellModifier#canModify(java.lang.Object, java.lang.String)
+     */
+    public boolean canModify(Object element, String property) {
+        if (element instanceof PropertyType && property.equalsIgnoreCase(VALUE_COLUMN)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @param element Object being modified
+     * @param property PropertyType being modified
+     * @return value of element property
+     * @see
+     * org.eclipse.jface.viewers.ICellModifier#getValue(java.lang.Object ,
+     * java.lang.String)
+     */
+    public Object getValue(Object element, String property) {
+        if (element instanceof PropertyType && property.equalsIgnoreCase(VALUE_COLUMN)) {
+            return ((PropertyType) element).getValue();
+        }
+        return null;
+    }
+
+    /**
+     * @param element Object being modified
+     * @param property PropertyType being modified
+     * @param value New property value
+     *
+     * @see org.eclipse.jface.viewers.ICellModifier#modify(java.lang.Object,
+     * java.lang.String, java.lang.Object)
+     */
+    public void modify(Object element, String property, final Object value) {
+        if (element instanceof TreeItem && property.equalsIgnoreCase(VALUE_COLUMN)) {
+            final TreeItem ti = (TreeItem) element;
+            if (getTargetObject() instanceof DomainType) {
+                final DomainType domainType = (DomainType) getTargetObject();
+                if (domainType.eContainer() != null) {
+                    TransactionalEditingDomain domain = SwitchyardSCAEditor.getActiveEditor().getEditingDomain();
+                    domain.getCommandStack().execute(new RecordingCommand(domain) {
+                        @Override
+                        protected void doExecute() {
+                            PropertyType parm = (PropertyType) ti.getData();
+                            setFeatureValue(parm, "value", value);
+                            getTreeViewer().refresh(true);
+                        }
+                    });
+                } else {
+                    PropertyType parm = (PropertyType) ti.getData();
+                    setFeatureValue(parm, "value", value);
+                    getTreeViewer().refresh(true);
+                }
+            }
+            fireChangedEvent(this);
+            // validate();
+        }
+    }
+
+    protected TreeViewer getTreeViewer() {
+        return this._propertyTreeTable;
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/impl/MultiPageEditor.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/impl/MultiPageEditor.java
@@ -14,6 +14,10 @@ package org.switchyard.tools.ui.editor.impl;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.emf.transaction.impl.TransactionalEditingDomainImpl;
 import org.eclipse.gef.ContextMenuProvider;
 import org.eclipse.gef.ui.actions.ActionRegistry;
 import org.eclipse.gef.ui.actions.WorkbenchPartAction;
@@ -25,15 +29,27 @@ import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabFolder2Listener;
 import org.eclipse.swt.custom.CTabFolderEvent;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.KeyListener;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.forms.widgets.FormToolkit;
+import org.eclipse.ui.forms.widgets.Section;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.ide.IGotoMarker;
 import org.eclipse.ui.part.EditorPart;
@@ -42,6 +58,17 @@ import org.eclipse.ui.part.MultiPageEditorPart;
 import org.eclipse.ui.part.MultiPageEditorSite;
 import org.eclipse.ui.part.MultiPageSelectionProvider;
 import org.eclipse.wst.sse.ui.StructuredTextEditor;
+import org.switchyard.tools.models.switchyard1_0.switchyard.DomainType;
+import org.switchyard.tools.models.switchyard1_0.switchyard.HandlerType;
+import org.switchyard.tools.models.switchyard1_0.switchyard.HandlersType;
+import org.switchyard.tools.models.switchyard1_0.switchyard.PropertiesType;
+import org.switchyard.tools.models.switchyard1_0.switchyard.PropertyType;
+import org.switchyard.tools.models.switchyard1_0.switchyard.SwitchYardType;
+import org.switchyard.tools.models.switchyard1_0.switchyard.SwitchyardFactory;
+import org.switchyard.tools.ui.editor.diagram.shared.DomainPropertyInputDialog;
+import org.switchyard.tools.ui.editor.diagram.shared.DomainPropertyTable;
+import org.switchyard.tools.ui.editor.model.merge.MergedModelUtil;
+import org.switchyard.tools.ui.editor.model.merge.SwitchYardMergedModelAdapter;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Node;
 
@@ -54,9 +81,14 @@ public class MultiPageEditor extends MultiPageEditorPart implements IGotoMarker 
     /** The text editor used in page 0. */
     private SwitchyardSCAEditor _diagramEditor;
     private StructuredTextEditor _sourceViewer;
+    private Composite _domainPage;
     // private TextEditor _textEditor;
     private CTabFolder _tabFolder;
     private int _defaultTabHeight;
+    private Button _messageTraceCheckbox;
+    private TransactionalEditingDomain _editDomain = null;
+    private SwitchYardType _syRoot = null;
+    private DomainPropertyTable _domainProperties = null;
 
     /**
      * Creates a multi-page editor example.
@@ -73,6 +105,12 @@ public class MultiPageEditor extends MultiPageEditorPart implements IGotoMarker 
     @Override
     public void dispose() {
         super.dispose();
+    }
+
+    private void addDomainListener() {
+        if (_editDomain == null) {
+            _editDomain = (TransactionalEditingDomainImpl) getDiagramEditor().getEditingDomain();
+        }
     }
 
     /**
@@ -103,6 +141,13 @@ public class MultiPageEditor extends MultiPageEditorPart implements IGotoMarker 
             throw new PartInitException("Invalid Input: Must be IFileEditorInput");
         }
         super.init(site, editorInput);
+    }
+    
+    private SwitchYardType getSwitchYardRoot() {
+        SwitchYardType switchYardRoot = MergedModelUtil.getSwitchYard(getDiagramEditor().getResourceSet().getResources().get(0));
+        SwitchYardMergedModelAdapter mergedAdapter =
+                MergedModelUtil.getAdapter(switchYardRoot, SwitchYardMergedModelAdapter.class);
+        return mergedAdapter.getSwitchYard();
     }
 
     /**
@@ -227,6 +272,255 @@ public class MultiPageEditor extends MultiPageEditorPart implements IGotoMarker 
         }
     }
 
+    private void addMessageTraceHandler() {
+        if (_syRoot != null) {
+            DomainType domain = _syRoot.getDomain();
+            if (domain == null) {
+                domain = SwitchyardFactory.eINSTANCE.createDomainType();
+                _syRoot.setDomain(domain);
+            }
+            HandlersType handlers = domain.getHandlers();
+            if (handlers == null) {
+                handlers = SwitchyardFactory.eINSTANCE.createHandlersType();
+                domain.setHandlers(handlers);
+            }
+            if (handlers != null) {
+                EList<HandlerType> handlersList = handlers.getHandler();
+                HandlerType messageTraceHandler = SwitchyardFactory.eINSTANCE.createHandlerType();
+                messageTraceHandler.setClass("org.switchyard.handlers.MessageTrace");
+                messageTraceHandler.setName("MessageTrace");
+                handlersList.add(messageTraceHandler);
+            }
+        }
+    }
+    
+    private EList<PropertyType> getDomainPropertyList() {
+        if (_syRoot != null) {
+            DomainType domain = _syRoot.getDomain();
+            if (domain != null) {
+                PropertiesType properties = domain.getProperties();
+                if (properties != null) {
+                    EList<PropertyType> propertyList = properties.getProperty();
+                    return propertyList;
+                }
+            }
+        }
+        return null;
+    }
+
+    private void removeDomainProperty( final PropertyType property) {
+        if (_syRoot != null) {
+            DomainType domain = _syRoot.getDomain();
+            if (domain != null) {
+                final PropertiesType properties = domain.getProperties();
+                if (properties != null) {
+                    _editDomain.getCommandStack().execute(new RecordingCommand(_editDomain) {
+                        @Override
+                        protected void doExecute() {
+                            properties.getProperty().remove(property);
+                        }
+                    });
+                }
+            }
+        }
+    }
+    
+    private void addDomainProperty(final String name, final String value) {
+        if (_syRoot != null) {
+            DomainType domain = _syRoot.getDomain();
+            if (domain == null) {
+                domain = SwitchyardFactory.eINSTANCE.createDomainType();
+                _syRoot.setDomain(domain);
+            }
+            final DomainType finalDomain = domain;
+            PropertiesType properties = domain.getProperties();
+            if (properties == null) {
+                properties = SwitchyardFactory.eINSTANCE.createPropertiesType();
+                final PropertiesType finalProperties = properties;
+                
+                _editDomain.getCommandStack().execute(new RecordingCommand(_editDomain) {
+                    @Override
+                    protected void doExecute() {
+                        finalDomain.setProperties(finalProperties);
+                    }
+                });
+            }
+            if (properties != null) {
+                final EList<PropertyType> propertyList = properties.getProperty();
+                final PropertyType newProperty = SwitchyardFactory.eINSTANCE.createPropertyType();
+                newProperty.setName(name);
+                newProperty.setValue(value);
+                _editDomain.getCommandStack().execute(new RecordingCommand(_editDomain) {
+                    @Override
+                    protected void doExecute() {
+                        propertyList.add(newProperty);
+                    }
+                });
+                _domainProperties.setSelection(propertyList);
+            }
+        }
+    }
+
+    private void removeMessageTraceHandler() {
+        if (_syRoot != null) {
+            DomainType domain = _syRoot.getDomain();
+            if (domain != null) {
+                HandlersType handlers = domain.getHandlers();
+                if (handlers != null) {
+                    EList<HandlerType> handlersList = handlers.getHandler();
+                    HandlerType handlerToRemove = null;
+                    for (HandlerType handler : handlersList) {
+                        if (handler.getName().equalsIgnoreCase("MessageTrace")
+                                && handler.getClass_().equalsIgnoreCase("org.switchyard.handlers.MessageTrace")) {
+                            handlerToRemove = handler;
+                            break;
+                        }
+                    }
+                    handlersList.remove(handlerToRemove);
+                }
+            }
+        }
+    }
+
+    private void updateMessageTraceHandler(final boolean value) {
+        if (_syRoot != null) {
+            boolean handlerExists = testForMessageTraceHandler();
+            if (handlerExists && !value) {
+                _editDomain.getCommandStack().execute(new RecordingCommand(_editDomain) {
+                    @Override
+                    protected void doExecute() {
+                        removeMessageTraceHandler();
+                    }
+                });
+            } else if (!handlerExists && value) {
+                _editDomain.getCommandStack().execute(new RecordingCommand(_editDomain) {
+                    @Override
+                    protected void doExecute() {
+                        addMessageTraceHandler();
+                    }
+                });
+            }
+        }
+    }
+
+    private boolean testForMessageTraceHandler() {
+        if (_syRoot != null) {
+            DomainType domain = _syRoot.getDomain();
+            if (domain != null) {
+                HandlersType handlers = domain.getHandlers();
+                if (handlers != null) {
+                    EList<HandlerType> handlersList = handlers.getHandler();
+                    for (HandlerType handler : handlersList) {
+                        if (handler.getName().equalsIgnoreCase("MessageTrace")
+                                && handler.getClass_().equalsIgnoreCase("org.switchyard.handlers.MessageTrace")) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private void createDomainPage() {
+        if (_domainPage == null) {
+            
+            FormToolkit toolkit = new FormToolkit(getContainer().getDisplay());
+            _domainPage = toolkit.createComposite(getContainer());
+            _domainPage.setLayout(new GridLayout(1, false));
+            
+            // Creating the Main Domain Settings section
+            Section section = toolkit.createSection(_domainPage, Section.TITLE_BAR);
+            section.setText("Domain Settings"); //$NON-NLS-1$
+            section.setLayout(new GridLayout(1, false));
+            section.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
+
+            // Composite for storing controls of the main section
+            Composite client = toolkit.createComposite(section, SWT.WRAP);
+            GridLayout layout = new GridLayout();
+            layout.numColumns = 2;
+            layout.marginWidth = 2;
+            layout.marginHeight = 2;
+            client.setLayout(layout);
+
+            _messageTraceCheckbox = toolkit.createButton(client, "Enable Message Trace", SWT.CHECK | SWT.LEFT); //$NON-NLS-1$
+            _messageTraceCheckbox.setLayoutData(new GridData(GridData.FILL, GridData.BEGINNING, true, false));
+            _messageTraceCheckbox.setSelection(testForMessageTraceHandler());
+            _messageTraceCheckbox.addSelectionListener(new SelectionListener() {
+
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    widgetDefaultSelected(e);
+                }
+
+                @Override
+                public void widgetDefaultSelected(SelectionEvent e) {
+                    if (_syRoot != null) {
+                        updateMessageTraceHandler(_messageTraceCheckbox.getSelection());
+                    }
+                }
+            });
+
+            _messageTraceCheckbox.addKeyListener(new KeyListener() {
+                @Override
+                public void keyPressed(KeyEvent e) {
+                    // ignore
+                }
+
+                @Override
+                public void keyReleased(KeyEvent e) {
+                    if (e.keyCode == SWT.CR) {
+                        updateMessageTraceHandler(_messageTraceCheckbox.getSelection());
+                    }
+                }
+            });
+            
+            Section section2 = toolkit.createSection(_domainPage, Section.TITLE_BAR);
+            section2.setText("Domain Properties"); //$NON-NLS-1$
+            section2.setLayout(new GridLayout(1, false));
+            section2.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
+
+            // Composite for storing controls of the main section
+            Composite client2 = toolkit.createComposite(section2, SWT.WRAP);
+            GridLayout layout2 = new GridLayout();
+            layout2.numColumns = 2;
+            layout2.marginWidth = 2;
+            layout2.marginHeight = 2;
+            client2.setLayout(layout2);
+
+            _domainProperties = new DomainPropertyTable(client2, SWT.NONE) {
+                
+                @Override
+                protected void removeFromList() {
+                    final PropertyType toRemove = _domainProperties.getTableSelection();
+                    if (toRemove != null) {
+                        removeDomainProperty(toRemove);
+                    }
+                }
+                
+                @Override
+                protected void addPropertyTypeToList() {
+                    final DomainPropertyInputDialog dialog = new DomainPropertyInputDialog(Display.getCurrent().getActiveShell());
+                    int rtn_value = dialog.open();
+                    if (rtn_value == DomainPropertyInputDialog.OK) {
+                        final String name = dialog.getPropertyName();
+                        final String value = dialog.getPropertyValue();
+                        addDomainProperty(name, value);
+                    }
+                    
+                }
+            };
+            _domainProperties.setLayoutData(new GridData(GridData.FILL, GridData.BEGINNING, true, false, 2, 5));
+            _domainProperties.setSelection(getDomainPropertyList());
+
+            section2.setClient(client2);
+            section.setClient(client);
+
+            int index = addPage(_domainPage);
+            setPageText(index, "Domain");          
+        }
+    }
+    
     protected void createDesignEditor() {
         if (_diagramEditor == null) {
             _diagramEditor = new DesignEditor();
@@ -243,6 +537,9 @@ public class MultiPageEditor extends MultiPageEditorPart implements IGotoMarker 
                 _defaultTabHeight = _tabFolder.getTabHeight();
 
                 updateTabs();
+
+                addDomainListener();
+                _syRoot = getSwitchYardRoot();
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -455,6 +752,7 @@ public class MultiPageEditor extends MultiPageEditorPart implements IGotoMarker 
 
         });
         createDesignEditor();
+        createDomainPage();
         createSourceViewer();
     }
 


### PR DESCRIPTION
This change:
- adds a new page to the multi-page SwitchYard editor called "Domain"
- moves the "Message Trace" checkbox from the Application property page to the new editor page
- removes the Application property page
- adds the ability to specify Properties at the Domain level

The Domain page will be where we add the new Security properties when they are available.
