### PR TITLE
SWITCHYARD-1448 constrain interface types based on component type

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.bpel/src/org/switchyard/tools/ui/bpel/BPELComponentTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpel/src/org/switchyard/tools/ui/bpel/BPELComponentTypeExtension.java
@@ -12,14 +12,19 @@
 package org.switchyard.tools.ui.bpel;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
+import org.eclipse.graphiti.features.context.ICreateContext;
 import org.eclipse.graphiti.tb.IImageDecorator;
 import org.eclipse.graphiti.tb.ImageDecorator;
+import org.eclipse.soa.sca.sca1_1.model.sca.Component;
 import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
 import org.open.oasis.docs.ns.opencsa.sca.bpel.BPELImplementation;
+import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
 import org.switchyard.tools.ui.editor.IComponentTypeExtension;
 import org.switchyard.tools.ui.editor.ImageProvider;
 import org.switchyard.tools.ui.editor.diagram.component.CreateComponentFeature;
@@ -34,6 +39,8 @@ import org.switchyard.tools.ui.editor.diagram.shared.CompositeCreateFeature;
  */
 public class BPELComponentTypeExtension implements IComponentTypeExtension {
 
+    private static final Set<InterfaceType> TYPES = EnumSet.of(InterfaceType.WSDL);
+
     @Override
     public ICreateFeature[] newCreateFeatures(IFeatureProvider fp) {
         return new ICreateFeature[] {new CompositeCreateFeature(fp, "Process (BPEL)",
@@ -41,7 +48,17 @@ public class BPELComponentTypeExtension implements IComponentTypeExtension {
                         new BPELComponentFactory(), "Process (BPEL)",
                         "Create a component implemented as a BPEL process.", ImageProvider.IMG_16_BPMN),
                 new CreateImplementationFeature(fp, new BPELImplementationFactory(), "Process (BPEL)",
-                        "An implementation using a BPEL process.")) };
+                        "An implementation using a BPEL process.") {
+                    @Override
+                    public boolean canCreate(ICreateContext context) {
+                        if (super.canCreate(context)) {
+                            return InterfaceType.interfacesAreCompatible(
+                                    (Component) getBusinessObjectForPictogramElement(context.getTargetContainer()),
+                                    TYPES);
+                        }
+                        return false;
+                    }
+                }) };
     }
 
     @Override
@@ -54,9 +71,18 @@ public class BPELComponentTypeExtension implements IComponentTypeExtension {
         return BPELImplementation.class.isAssignableFrom(type);
     }
 
-
     @Override
     public List<String> getRequiredCapabilities(Implementation object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-bpel");
+    }
+
+    @Override
+    public Set<InterfaceType> getSupportedInterfaceTypes(Implementation implementation) {
+        return TYPES;
+    }
+
+    @Override
+    public String getTypeName(Implementation object) {
+        return "BPEL";
     }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/component/BPMComponentTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/src/org/switchyard/tools/ui/bpmn2/component/BPMComponentTypeExtension.java
@@ -12,7 +12,9 @@
 package org.switchyard.tools.ui.bpmn2.component;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
@@ -20,6 +22,7 @@ import org.eclipse.graphiti.tb.IImageDecorator;
 import org.eclipse.graphiti.tb.ImageDecorator;
 import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
 import org.switchyard.tools.models.switchyard1_0.bpm.BPMImplementationType;
+import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
 import org.switchyard.tools.ui.editor.IComponentTypeExtension;
 import org.switchyard.tools.ui.editor.ImageProvider;
 import org.switchyard.tools.ui.editor.diagram.component.CreateComponentFeature;
@@ -54,9 +57,18 @@ public class BPMComponentTypeExtension implements IComponentTypeExtension {
         return BPMImplementationType.class.isAssignableFrom(type);
     }
 
-
     @Override
     public List<String> getRequiredCapabilities(Implementation object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-bpm");
+    }
+
+    @Override
+    public Set<InterfaceType> getSupportedInterfaceTypes(Implementation implementation) {
+        return EnumSet.allOf(InterfaceType.class);
+    }
+
+    @Override
+    public String getTypeName(Implementation object) {
+        return "BPM";
     }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/plugin.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/plugin.xml
@@ -377,6 +377,24 @@
                    class="Composite">
              </target>
           </constraint>
+          <constraint
+                class="org.switchyard.tools.ui.editor.validation.InterfaceTypeValidation"
+                id="org.switchyard.tools.validation.constraint/interfaceTypes"
+                isEnabledByDefault="true"
+                lang="Java"
+                mode="Batch"
+                name="SwitchYard Interface Type Validator"
+                statusCode="1003">
+             <message>
+                Validates that contracts provide an interface whose type is supported by the underlying implementation.
+             </message>
+             <target
+                   class="ComponentService">
+             </target>
+             <target
+                   class="ComponentReference">
+             </target>
+          </constraint>
        </constraints>
     </constraintProvider>
   </extension>

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/BindingTypeExtensionManager.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/BindingTypeExtensionManager.java
@@ -128,6 +128,11 @@ public final class BindingTypeExtensionManager {
         public List<String> getRequiredCapabilities(Binding object) {
             return Collections.emptyList();
         }
+
+        @Override
+        public String getTypeName(Binding object) {
+            return "Unknown";
+        }
     }
 
     private static final class DefaultBindingComposite extends AbstractSwitchyardComposite implements IBindingComposite {

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/ComponentTypeExtensionManager.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/ComponentTypeExtensionManager.java
@@ -14,9 +14,11 @@ package org.switchyard.tools.ui.editor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -26,7 +28,9 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.tb.ImageDecorator;
+import org.eclipse.soa.sca.sca1_1.model.sca.Component;
 import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
+import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
 
 /**
  * ComponentTypeExtensionManager
@@ -44,6 +48,24 @@ public final class ComponentTypeExtensionManager {
      */
     public static ComponentTypeExtensionManager instance() {
         return INSTANCE;
+    }
+
+    /**
+     * Helper method which returns the set of interface types supported by the
+     * component's implementation.
+     * 
+     * @param component the component to check.
+     * @return the set of supported interface types.
+     */
+    public static Set<InterfaceType> getSupportedInterfaceTypes(Component component) {
+        final Implementation implementation = component.getImplementation();
+        if (implementation == null) {
+            return EnumSet.allOf(InterfaceType.class);
+        }
+        final IComponentTypeExtension extension = ComponentTypeExtensionManager.instance().getExtensionFor(
+                implementation.getClass());
+        return extension == null ? Collections.<InterfaceType> emptySet() : extension
+                .getSupportedInterfaceTypes(implementation);
     }
 
     private Map<Class<? extends Implementation>, IComponentTypeExtension> _cache = new HashMap<Class<? extends Implementation>, IComponentTypeExtension>();
@@ -119,6 +141,16 @@ public final class ComponentTypeExtensionManager {
         @Override
         public List<String> getRequiredCapabilities(Implementation object) {
             return Collections.emptyList();
+        }
+
+        @Override
+        public Set<InterfaceType> getSupportedInterfaceTypes(Implementation implementation) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String getTypeName(Implementation object) {
+            return "Unknown";
         }
     }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/IComponentTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/IComponentTypeExtension.java
@@ -11,7 +11,10 @@
  ******************************************************************************/
 package org.switchyard.tools.ui.editor;
 
+import java.util.Set;
+
 import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
+import org.switchyard.tools.ui.common.InterfaceControl;
 
 /**
  * IComponentTypeExtension
@@ -27,5 +30,11 @@ import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
  * component.
  */
 public interface IComponentTypeExtension extends IEditorTypeExtension<Implementation> {
+
+    /**
+     * @param implementation the implementation
+     * @return the set of interface types supported by the implementation.
+     */
+    Set<InterfaceControl.InterfaceType> getSupportedInterfaceTypes(Implementation implementation);
 
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/IEditorTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/IEditorTypeExtension.java
@@ -43,6 +43,12 @@ public interface IEditorTypeExtension<T extends EObject> {
      * @return an IImageDecorator that represents the model object.
      */
     public IImageDecorator getImageDecorator(T object);
+    
+    /**
+     * @param object the model object.
+     * @return the display text for the object type.
+     */
+    public String getTypeName(T object);
 
     /**
      * @param type the type

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/bean/BeanComponentTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/bean/BeanComponentTypeExtension.java
@@ -12,7 +12,9 @@
 package org.switchyard.tools.ui.editor.components.bean;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
@@ -20,10 +22,9 @@ import org.eclipse.graphiti.features.context.ICreateContext;
 import org.eclipse.graphiti.tb.IImageDecorator;
 import org.eclipse.graphiti.tb.ImageDecorator;
 import org.eclipse.soa.sca.sca1_1.model.sca.Component;
-import org.eclipse.soa.sca.sca1_1.model.sca.ComponentService;
 import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
-import org.eclipse.soa.sca.sca1_1.model.sca.JavaInterface;
 import org.switchyard.tools.models.switchyard1_0.bean.BeanImplementationType;
+import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
 import org.switchyard.tools.ui.editor.IComponentTypeExtension;
 import org.switchyard.tools.ui.editor.ImageProvider;
 import org.switchyard.tools.ui.editor.diagram.component.CreateComponentFeature;
@@ -38,6 +39,8 @@ import org.switchyard.tools.ui.editor.diagram.shared.CompositeCreateFeature;
  */
 public class BeanComponentTypeExtension implements IComponentTypeExtension {
 
+    private static final Set<InterfaceType> TYPES = EnumSet.of(InterfaceType.Java);
+
     @Override
     public ICreateFeature[] newCreateFeatures(IFeatureProvider fp) {
         return new ICreateFeature[] {new CompositeCreateFeature(fp, "Bean",
@@ -49,21 +52,9 @@ public class BeanComponentTypeExtension implements IComponentTypeExtension {
                     @Override
                     public boolean canCreate(ICreateContext context) {
                         if (super.canCreate(context)) {
-                            Component component = (Component) getBusinessObjectForPictogramElement(context
-                                    .getTargetContainer());
-                            if (component.getService() == null) {
-                                // no service contract defined
-                                return true;
-                            }
-                            for (ComponentService service : component.getService()) {
-                                // only allow this if the component has a java
-                                // contract
-                                // defined
-                                return service.getInterface() == null
-                                        || service.getInterface() instanceof JavaInterface;
-                            }
-                            // no service contract defined
-                            return true;
+                            return InterfaceType.interfacesAreCompatible(
+                                    (Component) getBusinessObjectForPictogramElement(context.getTargetContainer()),
+                                    TYPES);
                         }
                         return false;
                     }
@@ -83,5 +74,15 @@ public class BeanComponentTypeExtension implements IComponentTypeExtension {
     @Override
     public List<String> getRequiredCapabilities(Implementation object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-bean");
+    }
+
+    @Override
+    public Set<InterfaceType> getSupportedInterfaceTypes(Implementation implementation) {
+        return TYPES;
+    }
+
+    @Override
+    public String getTypeName(Implementation object) {
+        return "Bean";
     }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/binding/sca/BindingSCATypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/binding/sca/BindingSCATypeExtension.java
@@ -58,4 +58,9 @@ public class BindingSCATypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-sca");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "SCA";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/CamelComponentTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/CamelComponentTypeExtension.java
@@ -12,7 +12,9 @@
 package org.switchyard.tools.ui.editor.components.camel;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
@@ -20,6 +22,7 @@ import org.eclipse.graphiti.tb.IImageDecorator;
 import org.eclipse.graphiti.tb.ImageDecorator;
 import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
 import org.switchyard.tools.models.switchyard1_0.camel.CamelImplementationType;
+import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
 import org.switchyard.tools.ui.editor.IComponentTypeExtension;
 import org.switchyard.tools.ui.editor.ImageProvider;
 import org.switchyard.tools.ui.editor.components.camel.java.CamelJavaComponentFactory;
@@ -74,5 +77,15 @@ public class CamelComponentTypeExtension implements IComponentTypeExtension {
     @Override
     public List<String> getRequiredCapabilities(Implementation object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel");
+    }
+
+    @Override
+    public Set<InterfaceType> getSupportedInterfaceTypes(Implementation implementation) {
+        return EnumSet.allOf(InterfaceType.class);
+    }
+
+    @Override
+    public String getTypeName(Implementation object) {
+        return "Camel";
     }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/binding/CamelBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/binding/CamelBindingTypeExtension.java
@@ -58,4 +58,9 @@ public class CamelBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-core");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "Camel URI";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/file/CamelFileBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/file/CamelFileBindingTypeExtension.java
@@ -62,4 +62,9 @@ public class CamelFileBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-file");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "File";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/ftp/CamelFTPBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/ftp/CamelFTPBindingTypeExtension.java
@@ -62,4 +62,9 @@ public class CamelFTPBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-ftp");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "FTP";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/jms/CamelJMSBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/jms/CamelJMSBindingTypeExtension.java
@@ -60,4 +60,9 @@ public class CamelJMSBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-jms");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "JMS";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/jpa/CamelJPABindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/jpa/CamelJPABindingTypeExtension.java
@@ -62,4 +62,9 @@ public class CamelJPABindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-jpa");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "JPA";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/mail/CamelMailBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/mail/CamelMailBindingTypeExtension.java
@@ -62,4 +62,9 @@ public class CamelMailBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-mail");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "Mail";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/netty/CamelNettyTCPBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/netty/CamelNettyTCPBindingTypeExtension.java
@@ -58,4 +58,9 @@ public class CamelNettyTCPBindingTypeExtension implements IBindingTypeExtension 
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-netty");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "TCP";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/netty/CamelNettyUDPBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/netty/CamelNettyUDPBindingTypeExtension.java
@@ -58,4 +58,9 @@ public class CamelNettyUDPBindingTypeExtension implements IBindingTypeExtension 
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-netty");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "UDP";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/quartz/CamelQuartzBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/quartz/CamelQuartzBindingTypeExtension.java
@@ -58,4 +58,9 @@ public class CamelQuartzBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-quartz");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "Scheduling";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/sql/CamelSQLBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/camel/sql/CamelSQLBindingTypeExtension.java
@@ -58,4 +58,9 @@ public class CamelSQLBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-camel-sql");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "SQL";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/http/HttpBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/http/HttpBindingTypeExtension.java
@@ -58,4 +58,9 @@ public class HttpBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-http");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "HTTP";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/jca/JCABindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/jca/JCABindingTypeExtension.java
@@ -62,4 +62,9 @@ public class JCABindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-jca");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "JCA";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/resteasy/ResteasyBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/resteasy/ResteasyBindingTypeExtension.java
@@ -58,4 +58,9 @@ public class ResteasyBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-resteasy");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "REST";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/rules/RulesComponentTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/rules/RulesComponentTypeExtension.java
@@ -12,7 +12,9 @@
 package org.switchyard.tools.ui.editor.components.rules;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.graphiti.features.ICreateFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
@@ -20,6 +22,7 @@ import org.eclipse.graphiti.tb.IImageDecorator;
 import org.eclipse.graphiti.tb.ImageDecorator;
 import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
 import org.switchyard.tools.models.switchyard1_0.rules.RulesImplementationType;
+import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
 import org.switchyard.tools.ui.editor.IComponentTypeExtension;
 import org.switchyard.tools.ui.editor.ImageProvider;
 import org.switchyard.tools.ui.editor.diagram.component.CreateComponentFeature;
@@ -56,5 +59,15 @@ public class RulesComponentTypeExtension implements IComponentTypeExtension {
     @Override
     public List<String> getRequiredCapabilities(Implementation object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-rules");
+    }
+
+    @Override
+    public Set<InterfaceType> getSupportedInterfaceTypes(Implementation implementation) {
+        return EnumSet.allOf(InterfaceType.class);
+    }
+
+    @Override
+    public String getTypeName(Implementation object) {
+        return "Rules";
     }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/soap/SOAPBindingTypeExtension.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/soap/SOAPBindingTypeExtension.java
@@ -58,4 +58,9 @@ public class SOAPBindingTypeExtension implements IBindingTypeExtension {
     public List<String> getRequiredCapabilities(Binding object) {
         return Collections.singletonList("org.switchyard.components:switchyard-component-soap");
     }
+
+    @Override
+    public String getTypeName(Binding object) {
+        return "SOAP";
+    }
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/componentreference/SCADiagramCreateComponentReferenceFeature.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/componentreference/SCADiagramCreateComponentReferenceFeature.java
@@ -22,6 +22,7 @@ import org.eclipse.soa.sca.sca1_1.model.sca.ComponentReference;
 import org.eclipse.soa.sca.sca1_1.model.sca.ScaPackage;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
+import org.switchyard.tools.ui.editor.ComponentTypeExtensionManager;
 import org.switchyard.tools.ui.editor.ImageProvider;
 import org.switchyard.tools.ui.editor.diagram.shared.BaseNewContractWizard;
 
@@ -49,6 +50,7 @@ public class SCADiagramCreateComponentReferenceFeature extends AbstractCreateFea
     public boolean canCreate(ICreateContext context) {
         final Object bo = getBusinessObjectForPictogramElement(context.getTargetContainer());
         return bo instanceof Component
+                && ComponentTypeExtensionManager.getSupportedInterfaceTypes((Component) bo).size() > 0
                 && !getDiagramEditor().getEditingDomain().isReadOnly(((Component) bo).eResource());
     }
 
@@ -57,7 +59,8 @@ public class SCADiagramCreateComponentReferenceFeature extends AbstractCreateFea
         ComponentReference newReference = null;
         Component component = (Component) getBusinessObjectForPictogramElement(context.getTargetContainer());
         BaseNewContractWizard wizard = new BaseNewContractWizard("New Reference",
-                "Specify details for the new reference.", ScaPackage.eINSTANCE.getComponentReference());
+                "Specify details for the new reference.", ScaPackage.eINSTANCE.getComponentReference(),
+                ComponentTypeExtensionManager.getSupportedInterfaceTypes(component));
         Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
         WizardDialog wizDialog = new WizardDialog(shell, wizard);
         wizard.init(component);

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/componentservice/SCADiagramCreateComponentServiceFeature.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/componentservice/SCADiagramCreateComponentServiceFeature.java
@@ -22,6 +22,7 @@ import org.eclipse.soa.sca.sca1_1.model.sca.ComponentService;
 import org.eclipse.soa.sca.sca1_1.model.sca.ScaPackage;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
+import org.switchyard.tools.ui.editor.ComponentTypeExtensionManager;
 import org.switchyard.tools.ui.editor.ImageProvider;
 import org.switchyard.tools.ui.editor.diagram.shared.BaseNewContractWizard;
 
@@ -49,6 +50,7 @@ public class SCADiagramCreateComponentServiceFeature extends AbstractCreateFeatu
     public boolean canCreate(ICreateContext context) {
         final Object bo = getBusinessObjectForPictogramElement(context.getTargetContainer());
         return bo instanceof Component && ((Component) bo).getService().size() == 0
+                && ComponentTypeExtensionManager.getSupportedInterfaceTypes((Component) bo).size() > 0
                 && !getDiagramEditor().getEditingDomain().isReadOnly(((Component) bo).eResource());
     }
 
@@ -57,7 +59,8 @@ public class SCADiagramCreateComponentServiceFeature extends AbstractCreateFeatu
         ComponentService newService = null;
         Component component = (Component) getBusinessObjectForPictogramElement(context.getTargetContainer());
         BaseNewContractWizard wizard = new BaseNewContractWizard("New Service", "Specify details for the new service.",
-                ScaPackage.eINSTANCE.getComponentService());
+                ScaPackage.eINSTANCE.getComponentService(),
+                ComponentTypeExtensionManager.getSupportedInterfaceTypes(component));
         Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
         WizardDialog wizDialog = new WizardDialog(shell, wizard);
         wizard.init(component);

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/BaseNewContractWizard.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/BaseNewContractWizard.java
@@ -10,6 +10,8 @@
  ************************************************************************************/
 package org.switchyard.tools.ui.editor.diagram.shared;
 
+import java.util.Set;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
@@ -17,6 +19,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
 import org.switchyard.tools.ui.PlatformResourceAdapterFactory;
+import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
 
 /**
  * BaseNewContractWizard
@@ -41,6 +44,21 @@ public class BaseNewContractWizard extends Wizard {
     public BaseNewContractWizard(String title, String description, EClass contractType) {
         _page = new NewContractWizardPage(NewContractWizardPage.class.getCanonicalName(), title, description,
                 contractType);
+        setWindowTitle(title);
+    }
+
+    /**
+     * Create a new BaseNewContractWizard.
+     * 
+     * @param title the title for the page (e.g. New Composite Service)
+     * @param description the description for the page.
+     * @param contractType the type of contract.
+     * @param interfaceTypes the available interface types
+     */
+    public BaseNewContractWizard(String title, String description, EClass contractType,
+            Set<InterfaceType> interfaceTypes) {
+        _page = new NewContractWizardPage(NewContractWizardPage.class.getCanonicalName(), title, description,
+                contractType, interfaceTypes);
         setWindowTitle(title);
     }
 

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/InterfaceChangeDialog.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/InterfaceChangeDialog.java
@@ -29,6 +29,7 @@ import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.soa.sca.sca1_1.model.sca.Component;
 import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
 import org.eclipse.soa.sca.sca1_1.model.sca.Interface;
 import org.eclipse.swt.SWT;
@@ -39,25 +40,33 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 import org.switchyard.tools.ui.common.InterfaceControl;
 import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
+import org.switchyard.tools.ui.editor.ComponentTypeExtensionManager;
 import org.switchyard.tools.ui.editor.impl.SwitchyardSCAEditor;
 
 /**
- * This dialog takes an incoming Contract (Service or Reference), prompts the user
- * to change it. 
+ * This dialog takes an incoming Contract (Service or Reference), prompts the
+ * user to change it.
+ * 
  * @author bfitzpat
- *
+ * 
  */
-public class InterfaceChangeDialog extends TitleAreaDialog 
-    implements ISelectionProvider {
-    
+public class InterfaceChangeDialog extends TitleAreaDialog implements ISelectionProvider {
+
+    private static Set<InterfaceType> getSupportedInterfaceTypes(Interface original) {
+        if (original.eContainer() == null || !(original.eContainer().eContainer() instanceof Component)) {
+            return EnumSet.allOf(InterfaceType.class);
+        }
+        return ComponentTypeExtensionManager.getSupportedInterfaceTypes((Component) original.eContainer().eContainer());
+    }
+
     private InterfaceControl _interfaceControl;
     private Contract _service;
     private Interface _originalInterface;
-    private Set<ISelectionChangedListener> _listeners = 
-            new LinkedHashSet<ISelectionChangedListener>();
+    private Set<ISelectionChangedListener> _listeners = new LinkedHashSet<ISelectionChangedListener>();
 
     /**
      * Opens a dialog to allow changing the interface.
+     * 
      * @param parentShell parent shell
      * @param container the container
      * @param originalIntfc the original interface class from the contract
@@ -65,8 +74,7 @@ public class InterfaceChangeDialog extends TitleAreaDialog
     public InterfaceChangeDialog(Shell parentShell, IContainer container, Interface originalIntfc) {
         super(parentShell);
         _originalInterface = originalIntfc;
-        _interfaceControl = new InterfaceControl(null, EnumSet.of(InterfaceType.Java, InterfaceType.WSDL,
-                InterfaceType.ESB));
+        _interfaceControl = new InterfaceControl(null, getSupportedInterfaceTypes(originalIntfc));
     }
 
     @Override
@@ -111,6 +119,7 @@ public class InterfaceChangeDialog extends TitleAreaDialog
 
     /**
      * Adds a new selection changed listener..
+     * 
      * @param listener New listener to add
      * @see org.eclipse.jface.viewers.ISelectionProvider#addSelectionChangedListener(org.eclipse.jface.viewers.ISelectionChangedListener)
      */
@@ -120,6 +129,7 @@ public class InterfaceChangeDialog extends TitleAreaDialog
 
     /**
      * Removes an existing selection changed listener..
+     * 
      * @param listener New listener to remove
      * @see org.eclipse.jface.viewers.ISelectionProvider#addSelectionChangedListener(org.eclipse.jface.viewers.ISelectionChangedListener)
      */
@@ -129,6 +139,7 @@ public class InterfaceChangeDialog extends TitleAreaDialog
 
     /**
      * Retrieve the current selection (returns the new interface).
+     * 
      * @return ISelection - containing the new interface
      * @see org.eclipse.jface.viewers.ISelectionProvider#getSelection()
      */
@@ -136,10 +147,11 @@ public class InterfaceChangeDialog extends TitleAreaDialog
         Interface intfc = _interfaceControl.getInterface();
         return new StructuredSelection(intfc);
     }
-    
+
     /**
-     * Sets the selection. In this case, it should be the incoming Contract with the interface
-     * to change.
+     * Sets the selection. In this case, it should be the incoming Contract with
+     * the interface to change.
+     * 
      * @param selection Incoming with Contract object
      * @see org.eclipse.jface.viewers.ISelectionProvider#setSelection(org.eclipse.jface.viewers.ISelection)
      */
@@ -151,7 +163,7 @@ public class InterfaceChangeDialog extends TitleAreaDialog
         if (_service.getInterface() != null) {
             Interface intfc = _service.getInterface();
             _interfaceControl.setSelection(new StructuredSelection(intfc));
-            
+
         }
     }
 
@@ -181,7 +193,7 @@ public class InterfaceChangeDialog extends TitleAreaDialog
         if (getErrorMessage() == null) {
             setMessage("Specify details for the new interface.");
         }
-        
+
         Interface intfc = _interfaceControl.getInterface();
         if (intfc.equals(_originalInterface)) {
             setMessage("Specify details for the new interface. Original interface type selected.");

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/NewContractWizardPage.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/NewContractWizardPage.java
@@ -11,6 +11,7 @@
 package org.switchyard.tools.ui.editor.diagram.shared;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.emf.ecore.EClass;
@@ -47,10 +48,23 @@ public class NewContractWizardPage extends WizardPage {
      * @param contractType the type of contract.
      */
     public NewContractWizardPage(String pageName, String title, String description, EClass contractType) {
+        this(pageName, title, description, contractType, EnumSet.of(InterfaceType.Java, InterfaceType.WSDL,
+                InterfaceType.ESB));
+    }
+
+    /**
+     * Create a new NewContractWizardPage.
+     * 
+     * @param pageName the page name
+     * @param title the page title
+     * @param description the description for the page.
+     * @param contractType the type of contract.
+     * @param interfaceTypes the available interface types
+     */
+    public NewContractWizardPage(String pageName, String title, String description, EClass contractType, Set<InterfaceType> interfaceTypes) {
         super(pageName, title, null);
         setDescription(description);
-        _contractControl = new ContractControl(contractType, null, EnumSet.of(InterfaceType.Java, InterfaceType.WSDL,
-                InterfaceType.ESB));
+        _contractControl = new ContractControl(contractType, null, interfaceTypes);
     }
 
     @Override

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/property/contract/ContractControlComposite.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/property/contract/ContractControlComposite.java
@@ -15,12 +15,14 @@ import java.util.EnumSet;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.soa.sca.sca1_1.model.sca.Component;
 import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
 import org.eclipse.soa.sca.sca1_1.model.sca.ScaPackage;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.switchyard.tools.ui.common.ContractControl;
 import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
+import org.switchyard.tools.ui.editor.ComponentTypeExtensionManager;
 import org.switchyard.tools.ui.editor.property.AbstractModelComposite;
 import org.switchyard.tools.ui.editor.property.ICompositeContainer;
 
@@ -70,8 +72,13 @@ public class ContractControlComposite extends AbstractModelComposite<Contract> {
         Contract contract = getTargetObject();
         if (contract != null) {
             _serviceControl.setSelection(new StructuredSelection(contract));
+            if (contract.eContainer() instanceof Component) {
+                _serviceControl.setSupportedInterfaceTypes(ComponentTypeExtensionManager
+                        .getSupportedInterfaceTypes((Component) contract.eContainer()));
+            } else {
+                _serviceControl.setSupportedInterfaceTypes(EnumSet.allOf(InterfaceType.class));
+            }
         }
         _inUpdate = false;
     }
-
 }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/property/intfc/InterfaceControlComposite.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/property/intfc/InterfaceControlComposite.java
@@ -16,12 +16,14 @@ import java.util.EnumSet;
 
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.soa.sca.sca1_1.model.sca.Component;
 import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
 import org.eclipse.soa.sca.sca1_1.model.sca.Interface;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.switchyard.tools.ui.common.InterfaceControl;
 import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
+import org.switchyard.tools.ui.editor.ComponentTypeExtensionManager;
 import org.switchyard.tools.ui.editor.property.AbstractModelComposite;
 import org.switchyard.tools.ui.editor.property.ICompositeContainer;
 
@@ -83,6 +85,12 @@ public class InterfaceControlComposite extends AbstractModelComposite<Contract> 
 
             // init controls
             _interfaceControl.init(_interface, null);
+            if (_service.eContainer() instanceof Component) {
+                _interfaceControl.setSupportedTypes(ComponentTypeExtensionManager
+                        .getSupportedInterfaceTypes((Component) contract.eContainer()));
+            } else {
+                _interfaceControl.setSupportedTypes(EnumSet.allOf(InterfaceType.class));
+            }
         }
         _inUpdate = false;
     }

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/validation/InterfaceTypeValidation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/validation/InterfaceTypeValidation.java
@@ -1,0 +1,74 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ *  All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ *
+ ******************************************************************************/
+package org.switchyard.tools.ui.editor.validation;
+
+import static org.switchyard.tools.ui.validation.ValidationProblem.IncompatibleInterfaceType;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.validation.AbstractModelConstraint;
+import org.eclipse.emf.validation.EMFEventType;
+import org.eclipse.emf.validation.IValidationContext;
+import org.eclipse.emf.validation.model.ConstraintStatus;
+import org.eclipse.soa.sca.sca1_1.model.sca.Component;
+import org.eclipse.soa.sca.sca1_1.model.sca.ComponentReference;
+import org.eclipse.soa.sca.sca1_1.model.sca.ComponentService;
+import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
+import org.eclipse.soa.sca.sca1_1.model.sca.Implementation;
+import org.eclipse.soa.sca.sca1_1.model.sca.Interface;
+import org.switchyard.tools.ui.common.InterfaceControl.InterfaceType;
+import org.switchyard.tools.ui.editor.ComponentTypeExtensionManager;
+import org.switchyard.tools.ui.editor.IComponentTypeExtension;
+
+/**
+ * InterfaceTypeValidation
+ * 
+ * <p/>
+ * Validates the interface used by a component service/reference is compatible
+ * with the implementation implementing the component.
+ */
+public class InterfaceTypeValidation extends AbstractModelConstraint {
+
+    @Override
+    public IStatus validate(IValidationContext ctx) {
+        EObject eObj = ctx.getTarget();
+        EMFEventType eType = ctx.getEventType();
+
+        // In the case of batch mode.
+        if (eType == EMFEventType.NULL) {
+            if (eObj instanceof ComponentReference || eObj instanceof ComponentService) {
+                return validate(ctx, (Contract) eObj);
+            }
+            // } else { // In the case of live mode.
+        }
+
+        return ctx.createSuccessStatus();
+    }
+
+    private IStatus validate(IValidationContext ctx, Contract contract) {
+        final Interface intf = contract.getInterface();
+        final Component component = (Component) contract.eContainer();
+        final Implementation implementation = component.getImplementation();
+        if (implementation == null) {
+            return ctx.createSuccessStatus();
+        }
+        final IComponentTypeExtension extension = ComponentTypeExtensionManager.instance().getExtensionFor(
+                implementation.getClass());
+        if (InterfaceType.isInstance(intf, extension.getSupportedInterfaceTypes(implementation))) {
+            return ctx.createSuccessStatus();
+        }
+        return ConstraintStatus.createStatus(ctx, contract, null, IncompatibleInterfaceType.getSeverity(),
+                IncompatibleInterfaceType.ordinal(), IncompatibleInterfaceType.getMessage(),
+                InterfaceType.valueOf(intf), extension.getTypeName(implementation), component.getName(),
+                contract.getName());
+    }
+}

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ContractControl.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/ContractControl.java
@@ -132,6 +132,13 @@ public class ContractControl implements ISelectionProvider {
     }
 
     /**
+     * @param supportedTypes the types of interfaces that should be available.
+     */
+    public void setSupportedInterfaceTypes(Set<InterfaceType> supportedTypes) {
+        _interfaceControl.setSupportedTypes(supportedTypes);
+    }
+
+    /**
      * @return the enablement state of the controls.
      */
     public boolean getEnabled() {

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ValidationProblem.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ValidationProblem.java
@@ -75,7 +75,13 @@ public enum ValidationProblem {
     /** Missing capability, e.g. SOAP binding, but no SOAP capability. */
     UnusedCapability(
             "Unused Capability: The \"{0}\" capability is configured on the project, but is not required by any SwitchYard binding or implementation types used in the project.",
-            IStatus.WARNING, false);
+            IStatus.WARNING, false),
+    /**
+     * Incompatible interface, e.g. a WSDL interface provided by a Bean service.
+     */
+    IncompatibleInterfaceType(
+            "Incompatible Interface Type: \"{0}\" interfaces cannot be used with \"{1}\" components ({2}/{3}).",
+            IStatus.ERROR, false);
 
     /** Used to identify the problem code attribute in IMarker objects. */
     public static final String PROBLEM_CODE = "ValidationProblem.code";

--- a/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/SwitchYardValidatorTest.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/SwitchYardValidatorTest.java
@@ -67,7 +67,7 @@ public class SwitchYardValidatorTest extends AbstractMavenProjectTestCase {
                 break;
             }
         }
-        assertEquals("Expecting 14 errors: " + WorkspaceHelpers.toString(markers), 14, errorCount);
+        assertEquals("Expecting 18 errors: " + WorkspaceHelpers.toString(markers), 18, errorCount);
         assertEquals("Expecting 4 warnings: " + WorkspaceHelpers.toString(markers), 4, warningCount);
         assertEquals("Expecting 0 infos: " + WorkspaceHelpers.toString(markers), 0, infoCount);
         assertEquals("Unexpected marker severity (not info, warning, error): " + WorkspaceHelpers.toString(markers), 0,

--- a/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validator-tests/wiring-validation-tests/pom.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validator-tests/wiring-validation-tests/pom.xml
@@ -7,7 +7,7 @@
   <version>0.0.1-SNAPSHOT</version>
   <name>org.switchyard.tools.tests:wiring-validation-tests</name>
   <properties>
-    <switchyard.version>0.8.0-SNAPSHOT</switchyard.version>
+    <switchyard.version>1.0.0-SNAPSHOT</switchyard.version>
   </properties>
   <dependencies>
     <dependency>

--- a/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validator-tests/wiring-validation-tests/src/main/java/org/switchyard/tools/tests/wiring_validation_tests/InvalidInterfaceComponent.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validator-tests/wiring-validation-tests/src/main/java/org/switchyard/tools/tests/wiring_validation_tests/InvalidInterfaceComponent.java
@@ -1,0 +1,26 @@
+package org.switchyard.tools.tests.wiring_validation_tests;
+
+import org.switchyard.component.bean.Service;
+
+@Service(value = BaseService.class, name = "WSDLService")
+public class InvalidInterfaceComponent implements BaseService {
+
+	@Override
+	public int testInOutMethod(String input) {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public void testInOnlyMethod(String input) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public int testFaultMethod(String input) throws Exception {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+}

--- a/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validator-tests/wiring-validation-tests/src/main/resources/META-INF/switchyard.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/test-data/validator-tests/wiring-validation-tests/src/main/resources/META-INF/switchyard.xml
@@ -38,8 +38,7 @@
       <sca:reference name="BaseReference">
         <sca:interface.java interface="org.switchyard.tools.tests.wiring_validation_tests.BaseService"/>
       </sca:reference>
-      <sca:service name="MissingInterface">
-      </sca:service>
+      <sca:service name="MissingInterface"/>
     </sca:component>
     <sca:component name="Component2">
       <sca:service name="ExtendedService">
@@ -66,5 +65,14 @@
     <sca:service name="InheritedService" promote="AllOk/InheritedService"/>
     <sca:reference name="InheritedReference" multiplicity="0..1" promote="Component/InheritedReference Component2/InheritedReference"/>
     <sca:reference name="UnusedReference" multiplicity="0..1"/>
+    <sca:component name="InvalidInterfaceComponent">
+      <bean:implementation.bean class="org.switchyard.tools.tests.wiring_validation_tests.InvalidInterfaceComponent"/>
+      <sca:service name="WSDLService">
+        <sca:interface.wsdl interface="BaseService.wsdl#wsdl.porttype(BaseServicePortType)"/>
+      </sca:service>
+      <sca:reference name="WSDLReference">
+        <sca:interface.wsdl interface="BaseService.wsdl#wsdl.porttype(BaseServicePortType)"/>
+      </sca:reference>
+    </sca:component>
   </sca:composite>
 </switchyard>


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-1448

Also added a validator, which generates errors if incompatible interface types are used on a component (component service/reference).
