### PR TITLE
SWITCHYARD-1449 Add dependency on Eclipse BPEL editor feature

### DIFF
--- a/eclipse/features/org.switchyard.tools.bpel.feature/feature.xml
+++ b/eclipse/features/org.switchyard.tools.bpel.feature/feature.xml
@@ -19,6 +19,8 @@
 
    <requires>
       <import feature="org.switchyard.tools.feature" version="1.0.0.qualifier"/>
+      <import feature="org.eclipse.bpel.feature" version="1.0.2" match="compatible"/>
+      <import feature="org.eclipse.bpel.common.feature" version="1.0.2" match="compatible"/>
    </requires>
 
    <plugin

--- a/eclipse/features/org.switchyard.tools.feature/feature.xml
+++ b/eclipse/features/org.switchyard.tools.feature/feature.xml
@@ -35,6 +35,7 @@
       <import feature="org.eclipse.m2e.wtp.feature" version="0.16.0" match="greaterOrEqual"/>
       <import plugin="javax.wsdl" version="1.6.2" match="equivalent"/>
       <import feature="org.jboss.ide.eclipse.freemarker.feature" version="1.2.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.zest" version="1.5.0" match="compatible"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-1449

Ensures the user gets everything they need when installing bpel support.
