### PR TITLE
SWITCHYARD-1519 fix org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER warning

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.m2e/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.m2e/META-INF/MANIFEST.MF
@@ -9,5 +9,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.m2e.maven.runtime;bundle-version="1.0.0",
  org.eclipse.m2e.core;bundle-version="1.0.0",
  org.eclipse.wst.common.project.facet.core;bundle-version="1.4.0",
- org.eclipse.m2e.wtp;bundle-version="0.16.0"
+ org.eclipse.m2e.wtp;bundle-version="0.16.0",
+ org.eclipse.jdt.core;bundle-version="3.3.0"
 Bundle-Vendor: www.jboss.org

--- a/eclipse/plugins/org.switchyard.tools.m2e/src/org/switchyard/tools/m2e/SwitchYardProjectConfigurator.java
+++ b/eclipse/plugins/org.switchyard.tools.m2e/src/org/switchyard/tools/m2e/SwitchYardProjectConfigurator.java
@@ -14,6 +14,7 @@ import org.apache.maven.plugin.MojoExecution;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
@@ -22,6 +23,7 @@ import org.eclipse.m2e.core.project.configurator.ILifecycleMappingConfiguration;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionKey;
 import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
 import org.eclipse.m2e.wtp.ResourceCleaner;
+import org.eclipse.m2e.wtp.WTPProjectsUtil;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.IFacetedProjectWorkingCopy;
 import org.eclipse.wst.common.project.facet.core.IPreset;
@@ -77,6 +79,9 @@ public class SwitchYardProjectConfigurator extends AbstractProjectConfigurator {
                 // Remove any unwanted MANIFEST.MF the Facet installation has
                 // created
                 fileCleaner.cleanUp();
+                // remove M2E classpath container
+                WTPProjectsUtil.setNonDependencyAttributeToContainer(request.getProject(), new SubProgressMonitor(
+                        monitor, 1));
             }
         }
     }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/AbstractSwitchYardProjectOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/AbstractSwitchYardProjectOperation.java
@@ -51,6 +51,13 @@ import org.switchyard.tools.ui.common.impl.SwitchYardProjectManager;
  */
 public abstract class AbstractSwitchYardProjectOperation implements IWorkspaceRunnable {
 
+    private final static String BEANS_XML_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<beans xmlns=\"http://java.sun.com/xml/ns/javaee\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+            + "    xsi:schemaLocation=\"\n"
+            + "      http://java.sun.com/xml/ns/javaee \n"
+            + "      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd\">\n"
+            + "</beans>\n";
+    private final static byte[] BEANS_XML_BYTES;
     private ISwitchYardProjectWorkingCopy _workingCopy;
     private String _switchYardVersion;
     private Collection<ISwitchYardComponentExtension> _components;
@@ -219,7 +226,7 @@ public abstract class AbstractSwitchYardProjectOperation implements IWorkspaceRu
             // TODO: find the first resource root that would include a beans.xml
             // file
             IFile beansIFile = project.getFolder(resourceLocations[0]).getFile("META-INF/beans.xml");
-            CreateFileOperation op = new CreateFileOperation(beansIFile, null, null, "Creating beans.xml file.");
+            CreateFileOperation op = new CreateFileOperation(beansIFile, null, new ByteArrayInputStream(BEANS_XML_BYTES), "Creating beans.xml file.");
             op.execute(monitor, _uiInfo);
         }
     }
@@ -294,4 +301,13 @@ public abstract class AbstractSwitchYardProjectOperation implements IWorkspaceRu
         }
     }
 
+    static {
+        byte[] bytes = new byte[0];
+        try {
+            bytes = BEANS_XML_CONTENT.getBytes("UTF-8");
+        } catch (Exception e) {
+            bytes = BEANS_XML_CONTENT.getBytes();
+        }
+        BEANS_XML_BYTES = bytes;
+    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-1519

Also added beans element to beans.xml files to prevent xml warnings in new projects.  New projects are now created without any errors or warnings.
