### PR TITLE
SWITCHYARD-2008 - Getting rid of annoying "NLS unused message:

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/messages.properties
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/messages.properties
@@ -443,7 +443,6 @@ label_maximumResults=Maximum Results
 label_maxMessagesPerPollDefault0=Max Messages Per Poll (Default 0)
 label_messageSelector=Message Selector
 label_method=Method
-label_moveDefault=Move (Default .camel)
 label_moveDefaultDotCamel=Move (Default .camel)
 label_moveFailed=Move Failed
 label_moveOptions=Move Options


### PR DESCRIPTION
label_moveDefault" message

Be sure this PR gets processed after all the others just to make sure we actually get rid of it this time and it doesn't get re-added in a different PR. :)
