### PR TITLE
SWITCHYARD-1906 Removed option to close Source tab in editor.

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/impl/MultiPageEditor.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/impl/MultiPageEditor.java
@@ -615,7 +615,6 @@ public class MultiPageEditor extends MultiPageEditorPart implements IGotoMarker,
                 int pageIndex = _tabFolder.getItemCount();
                 FileEditorInput input = new FileEditorInput(_diagramEditor.getModelFile());
                 addPage(pageIndex, _sourceViewer, input);
-                _tabFolder.getItem(pageIndex).setShowClose(true);
 
                 setPageText(pageIndex, Messages.title_source);
                 updateTabs();


### PR DESCRIPTION
Solved https://issues.jboss.org/browse/SWITCHYARD-1906 . Solution tested.
