### PR TITLE
JBTIS-290 - set o.j.t.usage resolution for SwitchYard

### DIFF
--- a/eclipse/plugins/org.switchyard.tools/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.switchyard.tools
 Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ org.jboss.tools.usage;resolution:=optional;x-installation:=greedy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
SwitchYard is already being tracked in jbosstools-base usage however it needs the added line of meta-data to accurately track SwitchYard no matter how it gets installed.

This is need for the 8.0.0.Beta2 IS in December.
