### PR TITLE
SWITCHYARD-2314 Rename cxf quickstart to match convention used by other quickstarts

### DIFF
--- a/eclipse/tests/org.switchyard.tools.ui.tests/pom.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/pom.xml
@@ -250,7 +250,7 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.switchyard.quickstarts</groupId>
-                  <artifactId>switchyard-camel-cxf</artifactId>
+                  <artifactId>switchyard-camel-cxf-binding</artifactId>
                   <version>${version.switchyard.runtime}</version>
                   <outputDirectory>test-data/quickstart-configs/camel-cxf-binding</outputDirectory>
                 </artifactItem>


### PR DESCRIPTION
Rename cxf quickstart.
