### PR TITLE
FUSETOOLS-2018 - use latest TP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <!-- Just in case the Eclipse project version does not match the parent. -->
     <version.switchyard.runtime>2.1.0.Final</version.switchyard.runtime>
-    <jbtis.version>4.3.1.Final</jbtis.version>
+    <jbtis.version>4.3.4-SNAPSHOT</jbtis.version>
     
     <!-- Tycho versions -->
     <jboss-tycho-version>0.23.1</jboss-tycho-version>


### PR DESCRIPTION
- required to allow first deployment working before manual build

full fix will require to have https://github.com/fusesource/fuseide/pull/674 merged

--> not able to test it fully yet because I have issues with my Target Platforms