### PR TITLE
FUSETOOLS-2018 - handle refresh case where adding/removing capabilities

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/SwitchYardModelUtils.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/SwitchYardModelUtils.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.soa.sca.sca1_1.model.sca.Interface;
 import org.eclipse.soa.sca.sca1_1.model.sca.JavaInterface;
 import org.eclipse.soa.sca.sca1_1.model.sca.WSDLPortType;
@@ -265,7 +266,13 @@ public final class SwitchYardModelUtils {
         if (intf instanceof JavaInterface) {
             try {
                 JavaInterface javaIntfc = (JavaInterface) intf;
-                return JavaService.fromClass(Classes.forName(javaIntfc.getInterface()));
+                Class<?> interfaceClasses = Classes.forName(javaIntfc.getInterface());
+                if (interfaceClasses != null) {
+                    return JavaService.fromClass(interfaceClasses);
+                } else {
+                    throw new IllegalArgumentException(
+                            NLS.bind(Messages.SwitchYardModelUtils_InterfaceClassNotFound, javaIntfc.getInterface()));
+                }
             } catch (RuntimeException e) {
                 throw e;
             }

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/i18n/Messages.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/i18n/Messages.java
@@ -636,8 +636,10 @@ public final class Messages extends NLS {
     /**
      * Exception message when the Interface Type is Unsupported.
      */
+    public static String SwitchYardModelUtils_InterfaceClassNotFound;
+
     public static String SwitchYardModelUtils_InterfaceTypeUnsupportedException;
-    
+
     public static String SwitchYardProject_errorMessage_exceptionWhileLodingSYFile;
 
     public static String SwitchYardProject_taskMessage_loadingMavenConfig;

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/i18n/messages.properties
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/i18n/messages.properties
@@ -305,6 +305,7 @@ SwitchYardModelPropertySource_propertyDescriptor_name=Name
 SwitchYardModelPropertySource_propertyDescriptor_tns=Target Namespace
 SwitchYardModelPropertySource_propertyDescriptorDescription_name=The name for the SwitchYard application.
 SwitchYardModelPropertySource_propertyDescriptorDescription_tns=The target namespace for the SwitchYard application.
+SwitchYardModelUtils_InterfaceClassNotFound=The interface has not been resolved: {0} Please check dependencies and classpath of the project.
 SwitchYardModelUtils_InterfaceTypeUnsupportedException=Interface type is not supported: 
 SwitchYardProject_errorMessage_exceptionWhileLodingSYFile=Exception while loading switchyard.xml file.
 SwitchYardProject_taskMessage_loadingMavenConfig=Loading Maven configuration for SwitchYard project.

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ServiceInterfaceConstraint.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/ServiceInterfaceConstraint.java
@@ -18,11 +18,18 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.validation.AbstractModelConstraint;
 import org.eclipse.emf.validation.EMFEventType;
 import org.eclipse.emf.validation.IValidationContext;
+import org.eclipse.emf.workspace.util.WorkspaceSynchronizer;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.soa.sca.sca1_1.model.sca.ComponentReference;
 import org.eclipse.soa.sca.sca1_1.model.sca.Contract;
 import org.eclipse.soa.sca.sca1_1.model.sca.Interface;
+import org.eclipse.soa.sca.sca1_1.model.sca.JavaInterface;
 import org.eclipse.soa.sca.sca1_1.model.sca.Reference;
 import org.eclipse.soa.sca.sca1_1.model.sca.Service;
+import org.switchyard.extensions.java.JavaService;
+import org.switchyard.metadata.ServiceInterface;
+import org.switchyard.tools.ui.JavaUtil;
+import org.switchyard.tools.ui.SwitchYardModelUtils;
 
 /**
  * ServiceInterfaceConstraint
@@ -55,17 +62,66 @@ public class ServiceInterfaceConstraint extends AbstractModelConstraint {
                 // promoting.
                 return ctx.createSuccessStatus();
             } else if (contract instanceof Reference) {
-                List<ComponentReference> promotions = ((Reference) contract).getPromote();
-                if (promotions != null && promotions.size() > 1) {
-                    Interface baseInterface = promotions.get(0).getInterface();
+                return compareReferenceInterfaces(ctx, contract);
+            }
+            return ctx.createFailureStatus();
+        }
+        return ctx.createSuccessStatus();
+    }
+
+    // we have to do the classloader dance to check the project classloader for 
+    // the interface classes we need.
+    private IStatus compareReferenceInterfaces(IValidationContext ctx, Contract contract) {
+        boolean problemFound = false;
+        ClassLoader oldTCCL = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(
+                    JavaUtil.getProjectClassLoader(
+                            JavaCore.create(WorkspaceSynchronizer.getFile(contract.eResource()).getProject()), 
+                            getClass().getClassLoader()));
+            List<ComponentReference> promotions = ((Reference) contract).getPromote();
+            if (promotions != null && promotions.size() > 1) {
+                Interface baseInterface = promotions.get(0).getInterface();
+                if (baseInterface instanceof JavaInterface) {
+                    JavaInterface baseJavaInterface = (JavaInterface) baseInterface;
+                    for (ComponentReference promotedReference : promotions) {
+                        Interface comparedInterface = promotedReference.getInterface();
+                        if (baseInterface instanceof JavaInterface) {
+                            JavaInterface comparedJavaInterface = (JavaInterface) comparedInterface;
+                            try {
+                                ServiceInterface baseSvcInterface = SwitchYardModelUtils.getServiceInterface(baseJavaInterface);
+                                ServiceInterface compareSvcInterface = SwitchYardModelUtils.getServiceInterface(comparedJavaInterface);
+                                JavaService baseJavaSvc = (JavaService) baseSvcInterface;
+                                JavaService compareJavaSvc = (JavaService) compareSvcInterface;
+                                if (!baseJavaSvc.getJavaInterface().isAssignableFrom(compareJavaSvc.getJavaInterface())) {
+                                    problemFound = true;
+                                    break;
+                                }                                                                            
+                            } catch (Exception e1) {
+                                problemFound = true;
+                                break;
+                            }
+                        } else if (!EcoreUtil.equals(baseInterface, promotedReference.getInterface())) {
+                            problemFound = true;
+                            break;
+                        }
+                    }
+                    
+                } else {
                     for (ComponentReference promotedReference : promotions) {
                         if (!EcoreUtil.equals(baseInterface, promotedReference.getInterface())) {
-                            return ctx.createFailureStatus();
+                            problemFound = true;
+                            break;
                         }
                     }
                 }
-                return ctx.createSuccessStatus();
             }
+        } catch (Exception e) {
+            problemFound = true;
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldTCCL);
+        }
+        if (problemFound) {
             return ctx.createFailureStatus();
         }
         return ctx.createSuccessStatus();

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/WiringValidationContext.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/validation/WiringValidationContext.java
@@ -262,8 +262,10 @@ final class WiringValidationContext {
                             _serviceInterfaces.put((Contract) eobject, si);
                         }
                     } catch (Exception e) {
+                        Activator.getDefault().getLog().log(new Status(IStatus.INFO, Activator.PLUGIN_ID, "Service Interface cannot be loaded.", e)); //$NON-NLS-1$                        
                         if (e instanceof RuntimeException) {
-                            if (e.getMessage().startsWith("SWITCHYARD010004")) {
+                            String message = e.getMessage();
+                            if (message != null && message.startsWith("SWITCHYARD010004")) { //$NON-NLS-1$
                                 _serviceInterfaces.put((Contract) eobject, INVALID_SERVICE_INTERFACE);
                             } else {
                                 _serviceInterfaces.put((Contract) eobject, URESOLVABLE_SERVICE_INTERFACE);
@@ -277,7 +279,7 @@ final class WiringValidationContext {
         } catch (Exception e) {
             e.fillInStackTrace();
             _problems.add(new Status(Status.WARNING, Activator.PLUGIN_ID,
-                    Messages.WiringValidationContext_statusMessage_errorLoadingServiceInterfaceMetadata));
+                    Messages.WiringValidationContext_statusMessage_errorLoadingServiceInterfaceMetadata, e));
         } finally {
             Thread.currentThread().setContextClassLoader(oldTCCL);
         }

--- a/eclipse/tests/org.switchyard.tools.m2e.tests/src/org/switchyard/tools/m2e/tests/AbstractSwitchYardTest.java
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/src/org/switchyard/tools/m2e/tests/AbstractSwitchYardTest.java
@@ -1,0 +1,81 @@
+/*************************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.m2e.tests;
+
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
+import org.eclipse.m2e.tests.common.JobHelpers;
+import org.eclipse.m2e.tests.common.JobHelpers.IJobMatcher;
+
+/**
+ * Abstract test extending AbstractMavenProjectTestCase to handle timeout
+ * better.
+ * 
+ * @author brianf
+ */
+@SuppressWarnings("restriction")
+public abstract class AbstractSwitchYardTest extends AbstractMavenProjectTestCase {
+
+    private static final int DEFAULT_TIMEOUT_MS = 300 * 1000; // 5 minute max
+
+    /**
+     * Wait for all build jobs with a default timeout.
+     * 
+     * @throws Exception
+     */
+    protected void waitForJobs() throws Exception {
+        waitForJobs(DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * Wait for all build jobs with a parameterized timeout.
+     * 
+     * @throws Exception
+     */
+    protected void waitForJobs(int timeout) throws Exception {
+        JobHelpers.waitForJobs(BuildJobMatcher.INSTANCE, timeout);
+    }
+
+    /**
+     * Wait for all build jobs with a default timeout.
+     */
+    protected void waitForJobsNoThrow() {
+        try {
+            waitForJobsNoThrow(DEFAULT_TIMEOUT_MS);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Wait for all build jobs with a parameterized timeout.
+     * 
+     * @throws Exception
+     */
+    protected void waitForJobsNoThrow(int timeout) {
+        try {
+            JobHelpers.waitForJobs(BuildJobMatcher.INSTANCE, timeout);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    static class BuildJobMatcher implements IJobMatcher {
+
+        public static final IJobMatcher INSTANCE = new BuildJobMatcher();
+
+        public boolean matches(Job job) {
+            return (job instanceof WorkspaceJob) || job.getClass().getName().matches("(.*\\.AutoBuild.*)") //$NON-NLS-1$
+                    || job.getClass().getName().endsWith("JREUpdateJob"); //$NON-NLS-1$
+        }
+    }
+}

--- a/eclipse/tests/org.switchyard.tools.m2e.tests/src/org/switchyard/tools/m2e/tests/SwitchYardConfigurationTest.java
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/src/org/switchyard/tools/m2e/tests/SwitchYardConfigurationTest.java
@@ -1,5 +1,5 @@
 /*************************************************************************************
- * Copyright (c) 2011 Red Hat, Inc. and others.
+ * Copyright (c) 2011-2016 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.m2e.core.project.ResolverConfiguration;
-import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 
 /**
  * SwitchYardConfigurationTest
@@ -31,7 +30,7 @@ import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
  * @author Rob Cernich
  */
 @SuppressWarnings("restriction")
-public class SwitchYardConfigurationTest extends AbstractMavenProjectTestCase {
+public class SwitchYardConfigurationTest extends AbstractSwitchYardTest {
 
     /**
      * Tests import and configuration of bean-service quickstart.
@@ -107,11 +106,4 @@ public class SwitchYardConfigurationTest extends AbstractMavenProjectTestCase {
             }
         }
     }
-
-    private void waitForJobs() throws Exception {
-        waitForJobsToComplete();
-        // Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
-        // Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
-    }
-
 }

--- a/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/AbstractSwitchYardTest.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/AbstractSwitchYardTest.java
@@ -1,0 +1,81 @@
+/*************************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     JBoss by Red Hat - Initial implementation.
+ ************************************************************************************/
+package org.switchyard.tools.ui.tests;
+
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
+import org.eclipse.m2e.tests.common.JobHelpers;
+import org.eclipse.m2e.tests.common.JobHelpers.IJobMatcher;
+
+/**
+ * Abstract test extending AbstractMavenProjectTestCase to handle timeout
+ * better.
+ * 
+ * @author brianf
+ */
+@SuppressWarnings("restriction")
+public abstract class AbstractSwitchYardTest extends AbstractMavenProjectTestCase {
+
+    private static final int DEFAULT_TIMEOUT_MS = 300 * 1000; // 5 minute max
+
+    /**
+     * Wait for all build jobs with a default timeout.
+     * 
+     * @throws Exception
+     */
+    protected void waitForJobs() throws Exception {
+        waitForJobs(DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * Wait for all build jobs with a parameterized timeout.
+     * 
+     * @throws Exception
+     */
+    protected void waitForJobs(int timeout) throws Exception {
+        JobHelpers.waitForJobs(BuildJobMatcher.INSTANCE, timeout);
+    }
+
+    /**
+     * Wait for all build jobs with a default timeout.
+     */
+    protected void waitForJobsNoThrow() {
+        try {
+            waitForJobsNoThrow(DEFAULT_TIMEOUT_MS);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Wait for all build jobs with a parameterized timeout.
+     * 
+     * @throws Exception
+     */
+    protected void waitForJobsNoThrow(int timeout) {
+        try {
+            JobHelpers.waitForJobs(BuildJobMatcher.INSTANCE, timeout);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    static class BuildJobMatcher implements IJobMatcher {
+
+        public static final IJobMatcher INSTANCE = new BuildJobMatcher();
+
+        public boolean matches(Job job) {
+            return (job instanceof WorkspaceJob) || job.getClass().getName().matches("(.*\\.AutoBuild.*)") //$NON-NLS-1$
+                    || job.getClass().getName().endsWith("JREUpdateJob"); //$NON-NLS-1$
+        }
+    }
+}

--- a/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/CreateSwitchYardProjectTest.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/CreateSwitchYardProjectTest.java
@@ -1,5 +1,5 @@
 /*************************************************************************************
- * Copyright (c) 2011 Red Hat, Inc. and others.
+ * Copyright (c) 2011-2016 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 import org.switchyard.tools.ui.common.SwitchYardComponentExtensionManager;
@@ -51,7 +50,7 @@ import org.switchyard.tools.ui.wizards.NewSwitchYardProjectWizard;
  * @author Rob Cernich
  */
 @SuppressWarnings("restriction")
-public class CreateSwitchYardProjectTest extends AbstractMavenProjectTestCase {
+public class CreateSwitchYardProjectTest extends AbstractSwitchYardTest {
 
     /**
      * TODO: this is probably not the best way to do things. This one test
@@ -261,12 +260,6 @@ public class CreateSwitchYardProjectTest extends AbstractMavenProjectTestCase {
                 expectedReader = null;
             }
         }
-    }
-
-    private void waitForJobs() throws Exception {
-        waitForJobsToComplete();
-//        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
-//        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
     }
 
     /**

--- a/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/SwitchYardModelValidationTest.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/SwitchYardModelValidationTest.java
@@ -1,5 +1,5 @@
 /*************************************************************************************
- * Copyright (c) 2011 Red Hat, Inc. and others.
+ * Copyright (c) 2011-2016 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.switchyard.tools.models.switchyard1_0.switchyard.DocumentRoot;
 import org.switchyard.tools.models.switchyard1_0.switchyard.SwitchYardType;
 import org.switchyard.tools.models.switchyard1_0.switchyard.SwitchyardPackage;
@@ -31,8 +30,7 @@ import org.switchyard.tools.models.switchyard1_0.switchyard.util.SwitchyardResou
  * @author bfitzpat
  * 
  */
-@SuppressWarnings("restriction")
-public class SwitchYardModelValidationTest extends AbstractMavenProjectTestCase {
+public class SwitchYardModelValidationTest extends AbstractSwitchYardTest {
 
     /**
      * Tests import and configuration of bean-service quickstart.
@@ -341,10 +339,6 @@ public class SwitchYardModelValidationTest extends AbstractMavenProjectTestCase 
      */
     public void testDemosPolicySecurityCertQuickstart() throws Exception {
         runModelTest("demos/policy-security-cert");
-    }
-
-    private void waitForJobs() throws Exception {
-        waitForJobsToComplete();
     }
 
     /**

--- a/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/SwitchYardValidatorTest.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/SwitchYardValidatorTest.java
@@ -16,7 +16,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.m2e.core.MavenPlugin;
-import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.eclipse.m2e.tests.common.WorkspaceHelpers;
 import org.switchyard.tools.ui.validation.SwitchYardProjectValidator;
 
@@ -28,7 +27,7 @@ import org.switchyard.tools.ui.validation.SwitchYardProjectValidator;
  * @author Rob Cernich, Brian Fitzpatrick
  */
 @SuppressWarnings("restriction")
-public class SwitchYardValidatorTest extends AbstractMavenProjectTestCase {
+public class SwitchYardValidatorTest extends AbstractSwitchYardTest {
 
     /**
      * Tests wiring validation.
@@ -37,12 +36,12 @@ public class SwitchYardValidatorTest extends AbstractMavenProjectTestCase {
      */
     public void testWiringValidation() throws Exception {
         IProject project = importProject("test-data/validator-tests/wiring-validation-tests/pom.xml");
-        waitForJobsToComplete();
+        waitForJobs();
 
         project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-        waitForJobsToComplete();
+        waitForJobs();
         project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
-        waitForJobsToComplete();
+        waitForJobs();
 
         IFile switchYardFile = project.getFile("src/main/resources/META-INF/switchyard.xml");
         assertTrue("switchyard.xml does not exist.", switchYardFile != null && switchYardFile.exists());
@@ -69,19 +68,19 @@ public class SwitchYardValidatorTest extends AbstractMavenProjectTestCase {
                 break;
             }
         }
-        assertEquals("Expecting 16 errors: " + WorkspaceHelpers.toString(markers), 16, errorCount);
-        assertEquals("Expecting 6 warnings: " + WorkspaceHelpers.toString(markers), 6, warningCount);
+        assertEquals("Expecting 18 errors: " + WorkspaceHelpers.toString(markers), 18, errorCount);
+        assertEquals("Expecting 5 warnings: " + WorkspaceHelpers.toString(markers), 5, warningCount);
         assertEquals("Expecting 0 infos: " + WorkspaceHelpers.toString(markers), 0, infoCount);
         assertEquals("Unexpected marker severity (not info, warning, error): " + WorkspaceHelpers.toString(markers), 0, unknownCount);
 
         ensureMarkersCleanedOnProjectClean(project);
 
-        ensureValidationErrorFoundAfterFullBuild(project, switchYardFile, 21);
+        ensureValidationErrorFoundAfterFullBuild(project, switchYardFile, 23);
         
         MavenPlugin.getProjectConfigurationManager().updateProjectConfiguration(project, monitor);
         ensureMarkersCleanedOnProjectClean(project);
 
-        ensureValidationErrorFoundAfterFullBuild(project, switchYardFile, 21);
+        ensureValidationErrorFoundAfterFullBuild(project, switchYardFile, 23);
     }
 
     /**
@@ -91,12 +90,12 @@ public class SwitchYardValidatorTest extends AbstractMavenProjectTestCase {
      */
     public void testCamelRouteValidation() throws Exception {
         IProject project = importProject("test-data/validator-tests/camel-route-tests/pom.xml");
-        waitForJobsToComplete();
+        waitForJobs();
 
         project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-        waitForJobsToComplete();
+        waitForJobs();
         project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
-        waitForJobsToComplete();
+        waitForJobs();
 
         IFile switchYardFile = project.getFile("src/main/resources/META-INF/switchyard.xml");
         assertTrue("switchyard.xml does not exist.", switchYardFile != null && switchYardFile.exists());
@@ -142,15 +141,15 @@ public class SwitchYardValidatorTest extends AbstractMavenProjectTestCase {
 
     private void ensureValidationErrorFoundAfterFullBuild(IProject project, IFile switchYardFile, int expectedErrorCount) throws CoreException, InterruptedException {
         project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-        waitForJobsToComplete();
+        waitForJobsNoThrow();
         IMarker[] markers = switchYardFile.findMarkers(SwitchYardProjectValidator.SWITCHYARD_MARKER_ID, true, IFile.DEPTH_ZERO);
         assertEquals(WorkspaceHelpers.toString(markers), expectedErrorCount, markers.length);
     }
 
     private void ensureMarkersCleanedOnProjectClean(IProject project) throws InterruptedException, CoreException {
-        waitForJobsToComplete();
+        waitForJobsNoThrow();
         project.build(IncrementalProjectBuilder.CLEAN_BUILD, monitor);
-        waitForJobsToComplete();
+        waitForJobsNoThrow();
         IMarker[] markers = project.findMarkers(null, true, IFile.DEPTH_INFINITE);
         assertEquals(WorkspaceHelpers.toString(markers), 0, markers.length);
     }


### PR DESCRIPTION
And fix timeout issues in all m2e-based tests.

Also added a few missing bits that didn't make it into the Neon PR from
FUSETOOLS-2092 from the 2.1.x branch