### PR TITLE
SWITCHYARD-2907 - fix for configuration version change facet problem

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/CreateTypeFeature.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/shared/CreateTypeFeature.java
@@ -27,6 +27,7 @@ import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.ICreateContext;
 import org.eclipse.graphiti.features.impl.AbstractCreateFeature;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.switchyard.tools.ui.common.ISwitchYardComponentExtension;
@@ -166,23 +167,26 @@ public abstract class CreateTypeFeature<T extends EObject, C extends EObject> ex
                 capabilities.add(capability);
             }
         }
-        try {
-            ResourcesPlugin.getWorkspace().run(
+        Display.getDefault().asyncExec(new Runnable() {
+            @Override
+            public void run() {
+                try {
                     new AbstractSwitchYardProjectOperation(null, capabilities, false,
                             Messages.description_updateSwitchYardCapabilities, null) {
                         @Override
                         protected IProject getProject() {
                             return project;
                         }
-
                         @Override
                         protected void execute(IProgressMonitor monitor) throws CoreException {
                             // no extra work
                         }
-                    }, new NullProgressMonitor());
-        } catch (CoreException e) {
-            Activator.logStatus(e.getStatus());
-        }
+                    }.run(new NullProgressMonitor());
+                } catch (CoreException e) {
+                    Activator.logStatus(e.getStatus());
+                }
+            }
+        });
     }
 
     private IProject getContainingProject(T newObject) {

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/SwitchYardProjectWorkingCopy.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/common/impl/SwitchYardProjectWorkingCopy.java
@@ -40,6 +40,7 @@ import org.eclipse.m2e.core.ui.internal.editing.AddDependencyOperation;
 import org.eclipse.m2e.core.ui.internal.editing.PomEdits;
 import org.eclipse.m2e.core.ui.internal.editing.PomHelper;
 import org.eclipse.m2e.core.ui.internal.editing.RemoveDependencyOperation;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.wst.sse.core.StructuredModelManager;
 import org.eclipse.wst.sse.core.internal.undo.IStructuredTextUndoManager;
 import org.eclipse.wst.xml.core.internal.provisional.document.IDOMDocument;
@@ -333,16 +334,22 @@ public class SwitchYardProjectWorkingCopy implements ISwitchYardProjectWorkingCo
     }
 
     private void refreshProject(IProgressMonitor monitor) throws CoreException {
-        // update the project so we ensure a Project->Clean is done so the
-        // MANIFEST.MF is built and we don't run into trouble deploying the 
-        // project on a Fuse server.
-        IProject project = _switchYardProject.getSwitchYardFeaturesFile().getProject();
-        if (project != null) {
-            // update the maven project so we start in a deployable state
-            // with a valid MANIFEST.MF built as part of the build process.
-            Job updateJob = new UpdateMavenProjectJob(new IProject[] {project});
-            updateJob.schedule();
-        }
+        Display.getDefault().asyncExec(new Runnable() {
+            @Override
+            public void run() {
+                // update the project so we ensure a Project->Clean is done so
+                // the MANIFEST.MF is built and we don't run into trouble deploying
+                // the project on a Fuse server.
+                IProject project = _switchYardProject.getSwitchYardFeaturesFile().getProject();
+                if (project != null) {
+                    // update the maven project so we start in a deployable
+                    // state with a valid MANIFEST.MF built as part of the build
+                    // process.
+                    Job updateJob = new UpdateMavenProjectJob(new IProject[] {project });
+                    updateJob.schedule();
+                }
+            }
+        });
     }
     
     

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallActionDelegate.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/facets/SwitchYardFacetInstallActionDelegate.java
@@ -108,7 +108,7 @@ public class SwitchYardFacetInstallActionDelegate implements IDelegate {
                 // make sure test folders get removed, save initiating a maven
                 // project update
                 IMavenProjectFacade projectFacade = MavenPlugin.getMavenProjectRegistry().getProject(getProject());
-                if (projectFacade == null || projectFacade.getMavenProject() == null) {
+                if (projectFacade == null || projectFacade.getMavenProject(monitor) == null) {
                     throw new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID, Messages.SwitchYardFacetInstallActionDelegate_errorMessage_notAMavenProject));
                 }
                 WTPProjectsUtil.removeTestFolderLinks(getProject(), workingCopy.getMavenProject(), monitor, "/"); //$NON-NLS-1$

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateSwitchYardProjectOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/CreateSwitchYardProjectOperation.java
@@ -87,6 +87,7 @@ import org.switchyard.tools.ui.i18n.Messages;
  * 
  * @author Rob Cernich
  */
+@SuppressWarnings("restriction")
 public class CreateSwitchYardProjectOperation implements IWorkspaceRunnable {
 
     /**

--- a/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/UpdateProjectPomOperation.java
+++ b/eclipse/plugins/org.switchyard.tools.ui/src/org/switchyard/tools/ui/operations/UpdateProjectPomOperation.java
@@ -10,9 +10,12 @@
  ************************************************************************************/
 package org.switchyard.tools.ui.operations;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.m2e.core.ui.internal.UpdateMavenProjectJob;
 import org.switchyard.tools.ui.common.ISwitchYardProjectWorkingCopy;
 
 /**
@@ -22,6 +25,7 @@ import org.switchyard.tools.ui.common.ISwitchYardProjectWorkingCopy;
  * 
  * @author Rob Cernich
  */
+@SuppressWarnings("restriction")
 public class UpdateProjectPomOperation implements IWorkspaceRunnable {
 
     private final ISwitchYardProjectWorkingCopy _workingCopy;
@@ -39,9 +43,22 @@ public class UpdateProjectPomOperation implements IWorkspaceRunnable {
     public void run(IProgressMonitor monitor) throws CoreException {
         try {
             _workingCopy.commit(monitor);
+            refreshProject(monitor);
         } finally {
             monitor.done();
         }
     }
 
+    private void refreshProject(IProgressMonitor monitor) throws CoreException {
+        // update the project so we ensure a Project->Clean is done so the
+        // MANIFEST.MF is built and we don't run into trouble deploying the 
+        // project on a Fuse server.
+        IProject project = _workingCopy.getProject();
+        if (project != null) {
+            // update the maven project so we start in a deployable state
+            // with a valid MANIFEST.MF built as part of the build process.
+            Job updateJob = new UpdateMavenProjectJob(new IProject[] {project});
+            updateJob.schedule();
+        }
+    }
 }


### PR DESCRIPTION
Ok. So I have part of the issue resolved. The facet issue mentioned in SWITCHYARD-2907 is fixed with the fixes in this PR. And I finally addressed the threading problem from SWITCHYARD-2957 by using the trick suggested by Bob Brodt - wrapping it in the Display thread. With that in place I have not been able to reproduce it.

We still have the issue with the MergeAdapter throwing a NPE - but the workaround for that is to close the editor before updating the configuration version. I'll continue to investigate it but at least we're no longer blocked.