### PR TITLE
SWITCHYARD-2955 - second attempt

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.m2e/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.m2e/META-INF/MANIFEST.MF
@@ -12,5 +12,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.wst.common.project.facet.core;bundle-version="1.4.0",
  org.eclipse.m2e.wtp;bundle-version="0.16.0",
  org.eclipse.jdt.core;bundle-version="3.3.0",
- org.switchyard.tools.models.switchyard1_0
+ org.switchyard.tools.models.switchyard1_0,
+ org.eclipse.wst.jsdt.web.core,
+ org.eclipse.jpt.jpa.core,
+ org.eclipse.jst.common.project.facet.core,
+ org.eclipse.wst.common.project.facet.core
 Bundle-Vendor: %Bundle-Vendor

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/META-INF/MANIFEST.MF
@@ -52,7 +52,8 @@ Require-Bundle: org.eclipse.graphiti;bundle-version="[0.10.0,0.14.0)",
  com.google.guava,
  org.jboss.tools.foundation.core,
  org.fusesource.ide.camel.model.service.core,
- org.fusesource.ide.camel.editor
+ org.fusesource.ide.camel.editor,
+ org.fusesource.ide.projecttemplates
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.switchyard.tools.ui.editor,

--- a/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
@@ -44,7 +44,9 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.ide.eclipse.as.wtp.ui,
  org.fusesource.ide.server.karaf.core,
  org.eclipse.jdt.launching,
- org.jboss.ide.eclipse.as.wtp.core
+ org.jboss.ide.eclipse.as.wtp.core,
+ org.jboss.tools.maven.core,
+ org.fusesource.ide.server.fuse.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.switchyard.tools.ui,

--- a/eclipse/tests/org.switchyard.tools.m2e.tests/META-INF/MANIFEST.MF
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.jst.jee.web;bundle-version="1.0.0",
  org.eclipse.jst.standard.schemas;bundle-version="1.0.0",
  org.eclipse.platform,
- org.eclipse.equinox.event
+ org.eclipse.equinox.event,
+ org.fusesource.ide.projecttemplates
 Bundle-ClassPath: lib/xmlunit.jar,
  .

--- a/eclipse/tests/org.switchyard.tools.ui.tests/META-INF/MANIFEST.MF
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/META-INF/MANIFEST.MF
@@ -26,6 +26,11 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.switchyard.tools.ui.bpel,
  org.switchyard.tools.ui.bpmn2,
  org.eclipse.m2e.core;bundle-version="[1.4.0,2.0.0)",
- org.eclipse.equinox.event
+ org.eclipse.equinox.event,
+ org.eclipse.wst.common.project.facet.core,
+ org.eclipse.jst.common.project.facet.core,
+ org.eclipse.wst.common.project.facet.ui,
+ org.eclipse.jst.common.project.facet.ui,
+ org.fusesource.ide.camel.model.service.v2_17_3
 Bundle-ClassPath: .,
  lib/xmlunit.jar

--- a/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/AbstractSwitchYardTest.java
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/src/org/switchyard/tools/ui/tests/AbstractSwitchYardTest.java
@@ -10,7 +10,10 @@
  ************************************************************************************/
 package org.switchyard.tools.ui.tests;
 
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.m2e.tests.common.AbstractMavenProjectTestCase;
 import org.eclipse.m2e.tests.common.JobHelpers;
@@ -26,15 +29,6 @@ import org.eclipse.m2e.tests.common.JobHelpers.IJobMatcher;
 public abstract class AbstractSwitchYardTest extends AbstractMavenProjectTestCase {
 
     private static final int DEFAULT_TIMEOUT_MS = 300 * 1000; // 5 minute max
-
-    /**
-     * Wait for all build jobs with a default timeout.
-     * 
-     * @throws Exception
-     */
-    protected void waitForJobs() throws Exception {
-        waitForJobs(DEFAULT_TIMEOUT_MS);
-    }
 
     /**
      * Wait for all build jobs with a parameterized timeout.
@@ -76,6 +70,20 @@ public abstract class AbstractSwitchYardTest extends AbstractMavenProjectTestCas
         public boolean matches(Job job) {
             return (job instanceof WorkspaceJob) || job.getClass().getName().matches("(.*\\.AutoBuild.*)") //$NON-NLS-1$
                     || job.getClass().getName().endsWith("JREUpdateJob"); //$NON-NLS-1$
+        }
+    }
+
+    protected void waitForJobs() throws OperationCanceledException, InterruptedException {
+        try {
+            Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, new NullProgressMonitor());
+            Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, new NullProgressMonitor());
+            Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, new NullProgressMonitor());
+            Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, new NullProgressMonitor());
+        } catch (InterruptedException ex) {
+            // Workaround to bug
+            // https://bugs.eclipse.org/bugs/show_bug.cgi?id=335251
+            System.out.println("Have a trace in case of infinite loop in AbstractSwitchYardTest.waitJob()");
+            waitForJobs();
         }
     }
 }

--- a/eclipse/tests/pom.xml
+++ b/eclipse/tests/pom.xml
@@ -13,7 +13,7 @@
   <description>Parent project for SwitchYard Eclipse plugin tests</description>
 
   <properties>
-    <tycho.test.jvmArgs>-XX:MaxPermSize=256m</tycho.test.jvmArgs>
+    <tycho.test.jvmArgs>-XX:MaxMetaspaceSize=256m</tycho.test.jvmArgs>
   </properties>
 
   <modules>
@@ -56,7 +56,7 @@
         </property>
       </activation>
       <properties>
-        <tycho.test.jvmArgs>-Xmx800m -XX:MaxPermSize=256m -XstartOnFirstThread</tycho.test.jvmArgs>
+        <tycho.test.jvmArgs>-Xmx800m -XX:MaxMetaspaceSize=256m -XstartOnFirstThread</tycho.test.jvmArgs>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
 A few changes to
- eliminate the "org.eclipse.wst.common.project.facet.core" warnings in the console
- eliminate a hang in testing when waiting for processes to finish 
- update the old "MaxPermSize=256m" setting to "MaxMetaspaceSize=256m" for Java 8