### PR TITLE
SWITCHYARD-2963 - adding a check to ensure that the runtime is 2.1 or

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/soap/SOAPBindingServiceComposite.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/soap/SOAPBindingServiceComposite.java
@@ -217,15 +217,19 @@ public class SOAPBindingServiceComposite extends AbstractSYBindingComposite {
             _mWSDLSocketText.setLayoutData(portGD);
         }
 
+        refreshIs21Model();
+        
         _unwrappedPayloadCheckbox = createCheckbox(composite, Messages.label_unwrappedPayload);
         GridData upChxGD = new GridData(GridData.FILL_HORIZONTAL);
         upChxGD.horizontalSpan = 3;
         _unwrappedPayloadCheckbox.setLayoutData(upChxGD);
+        _unwrappedPayloadCheckbox.setEnabled(is21Model());
         
         _copyNamespacesCheckbox = createCheckbox(composite, Messages.SOAPBindingReferenceComposite_label_copyNamespaces);
         GridData cnChxGD = new GridData(GridData.FILL_HORIZONTAL);
         cnChxGD.horizontalSpan = 3;
         _copyNamespacesCheckbox.setLayoutData(upChxGD);
+        _copyNamespacesCheckbox.setEnabled(is21Model());
 
         _soapHeadersTypeCombo = createLabelAndComboViewer(composite, Messages.label_soapHeadersType, true);
         GridData cmcGD = new GridData(GridData.FILL_HORIZONTAL);

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/binding/AbstractSYBindingComposite.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/diagram/binding/AbstractSYBindingComposite.java
@@ -15,6 +15,11 @@ package org.switchyard.tools.ui.editor.diagram.binding;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
@@ -27,6 +32,7 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.forms.widgets.FormToolkit;
+import org.switchyard.tools.ui.SwitchYardModelUtils;
 import org.switchyard.tools.ui.editor.Activator;
 import org.switchyard.tools.ui.editor.diagram.shared.AbstractSwitchyardComposite;
 import org.switchyard.tools.ui.editor.diagram.shared.IBindingComposite;
@@ -44,6 +50,7 @@ public abstract class AbstractSYBindingComposite extends AbstractSwitchyardCompo
     private EObject _targetObj = null;
     private boolean _didSomething = false;
     private static int DELAY_DEFAULT = 500;
+    private boolean _is21Model = true;
 
     protected AbstractSYBindingComposite(FormToolkit toolkit) {
         super(toolkit);
@@ -246,4 +253,29 @@ public abstract class AbstractSYBindingComposite extends AbstractSwitchyardCompo
         }
     }
 
+    protected boolean isVersion21OrHigher() {
+        String version = null;
+        if (getTargetObject() != null) {
+            URI uri = getTargetObject().eResource().getURI();
+            IFile tempFile = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(uri.toPlatformString(true)));
+            if (tempFile != null) {
+                IProject project = tempFile.getProject();
+                version = SwitchYardModelUtils.getSwitchYardProjectRuntimeVersion(project);
+            }
+        }
+        // if it's 1.0, 1.1, or 2.0.x ...
+        if (version != null && (version.startsWith("2.0") || version.startsWith("1"))) {
+            return false;
+        }
+        // otherwise it's higher
+        return true;
+    }
+
+    protected boolean is21Model() {
+        return _is21Model;
+    }
+    
+    protected void refreshIs21Model() {
+        _is21Model = isVersion21OrHigher();
+    }
 }


### PR DESCRIPTION
higher for the new unwrapped and copyNamespaces options to be saved in
the configuration file.

- also add a utility in the base class so we can reuse this
functionality if we need to do this kind of check again