### PR TITLE
FUSETOOLS-2205 - Add fragment dependency in test TP

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -94,6 +94,15 @@
         <version>${tychoVersion}</version>
         <configuration>
           <resolver>p2</resolver>
+          <dependency-resolution>
+			<extraRequirements>
+				<requirement>
+					<type>p2-installable-unit</type>
+					<id>org.eclipse.osgi.compatibility.state</id>
+					<versionRange>0.0.0</versionRange>
+				</requirement>
+			</extraRequirements>
+		  </dependency-resolution>
           <target>
             <artifact>
               <groupId>org.jboss.tools.integration-stack</groupId>


### PR DESCRIPTION
org.eclipse.osgi.compatibility.state is required but is no more by
default in the test Target Platform, so add it explicitly as M2E
utilities tests requires it