### PR TITLE
JBDS-4200 can't see any actual dependency on...

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.core/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.core/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
- org.apache.log4j;bundle-version="1.2.15",
- org.slf4j.api;bundle-version="1.6.0"
+ org.apache.log4j;bundle-version="1.2.15"
 Bundle-ClassPath: .,
  lib/switchyard-api.jar,
  lib/switchyard-common.jar,


### PR DESCRIPTION
JBDS-4200 can't see any actual dependency on org.slf4j.api so remove this from Require-Bundle list. If you actually need this, then please switch to Import-Package instead

Signed-off-by: nickboldt <nboldt@redhat.com>