### PR TITLE
SWITCHYARD-2984 - fixed issue with unwrapped checkbox on soap bindings

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/soap/SOAPBindingServiceComposite.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/soap/SOAPBindingServiceComposite.java
@@ -223,7 +223,6 @@ public class SOAPBindingServiceComposite extends AbstractSYBindingComposite {
         GridData upChxGD = new GridData(GridData.FILL_HORIZONTAL);
         upChxGD.horizontalSpan = 3;
         _unwrappedPayloadCheckbox.setLayoutData(upChxGD);
-        _unwrappedPayloadCheckbox.setEnabled(is21Model());
         
         _copyNamespacesCheckbox = createCheckbox(composite, Messages.SOAPBindingReferenceComposite_label_copyNamespaces);
         GridData cnChxGD = new GridData(GridData.FILL_HORIZONTAL);
@@ -603,11 +602,29 @@ public class SOAPBindingServiceComposite extends AbstractSYBindingComposite {
                 if (unwrapped != null || copyNamespaces != null) {
                     final MessageComposerType msgComposer = SOAPFactory.eINSTANCE
                             .createMessageComposerType();
-                    if (unwrapped != null) {
-                        msgComposer.setUnwrapped(unwrapped.booleanValue());
+                    final MessageComposerType oldMsgComposer = _binding.getMessageComposer();
+                    boolean unwrappedChanged = true;
+                    if (oldMsgComposer == null && unwrapped != null) {
+                    	unwrappedChanged = true;
+                    } else if (oldMsgComposer != null && oldMsgComposer.isUnwrapped() == unwrapped.booleanValue()) {
+                    	unwrappedChanged = false;
                     }
-                    if (copyNamespaces != null) {
-                        msgComposer.setCopyNamespaces(copyNamespaces.booleanValue());
+                    if (unwrapped != null && unwrappedChanged) {
+                        msgComposer.setUnwrapped(unwrapped.booleanValue());
+                    } else if (oldMsgComposer != null && !unwrappedChanged) {
+                    	msgComposer.setUnwrapped(oldMsgComposer.isUnwrapped());
+                    }
+                    boolean copyNamespacesChanged = true;
+                    if (oldMsgComposer == null && copyNamespaces != null) {
+                    	copyNamespacesChanged = true;
+                    } else if (oldMsgComposer != null && oldMsgComposer.isCopyNamespaces() == copyNamespaces.booleanValue()) {
+                    	copyNamespacesChanged = false;
+                    }
+                    if (copyNamespaces != null && copyNamespaces.booleanValue() && copyNamespacesChanged) {
+                    	// if we have a change, push it up to the message composer
+                		msgComposer.setCopyNamespaces(copyNamespaces.booleanValue());
+                    } else if (oldMsgComposer != null && !copyNamespacesChanged) {
+                    	msgComposer.setCopyNamespaces(oldMsgComposer.isCopyNamespaces());
                     }
                     return msgComposer;
                 }


### PR DESCRIPTION
-- unwrapped checkbox now is always enabled across all versions
-- copynamespaces checkbox is handled a bit more intelligently to avoid
introducing validation errors in 2.0.x or below.