### PR TITLE
SWITCHYARD-2963 - fixing issue for copynamespaces in older versions

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/soap/SOAPBindingServiceComposite.java
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/src/org/switchyard/tools/ui/editor/components/soap/SOAPBindingServiceComposite.java
@@ -615,16 +615,20 @@ public class SOAPBindingServiceComposite extends AbstractSYBindingComposite {
                     	msgComposer.setUnwrapped(oldMsgComposer.isUnwrapped());
                     }
                     boolean copyNamespacesChanged = true;
-                    if (oldMsgComposer == null && copyNamespaces != null) {
-                    	copyNamespacesChanged = true;
-                    } else if (oldMsgComposer != null && oldMsgComposer.isCopyNamespaces() == copyNamespaces.booleanValue()) {
-                    	copyNamespacesChanged = false;
-                    }
-                    if (copyNamespaces != null && copyNamespaces.booleanValue() && copyNamespacesChanged) {
-                    	// if we have a change, push it up to the message composer
-                		msgComposer.setCopyNamespaces(copyNamespaces.booleanValue());
-                    } else if (oldMsgComposer != null && !copyNamespacesChanged) {
-                    	msgComposer.setCopyNamespaces(oldMsgComposer.isCopyNamespaces());
+                    if (is21Model()) {
+	                    if (oldMsgComposer == null && copyNamespaces != null) {
+	                    	copyNamespacesChanged = true;
+	                    } else if (oldMsgComposer != null && oldMsgComposer.isCopyNamespaces() == copyNamespaces.booleanValue()) {
+	                    	copyNamespacesChanged = false;
+	                    }
+	                    if (copyNamespaces != null && copyNamespaces.booleanValue() && copyNamespacesChanged) {
+	                    	// if we have a change, push it up to the message composer
+	                		msgComposer.setCopyNamespaces(copyNamespaces.booleanValue());
+	                    } else if (oldMsgComposer != null && !copyNamespacesChanged) {
+	                    	msgComposer.setCopyNamespaces(oldMsgComposer.isCopyNamespaces());
+	                    }
+                    } else {
+                    	msgComposer.unsetCopyNamespaces();
                     }
                     return msgComposer;
                 }


### PR DESCRIPTION
-- check to see if we're on the 2.1+ version before doing anything with
the copyNamespaces option on soap service bindings to avoid adding it
where it should not be added