### PR TITLE
SWITCHYARD-2988 - updating TP

### DIFF
--- a/eclipse/plugins/org.switchyard.tools.core/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.core/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 2.3.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="3.11.0",
  org.apache.log4j;bundle-version="1.2.15"
 Bundle-ClassPath: .,
  lib/switchyard-api.jar,

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <!-- Just in case the Eclipse project version does not match the parent. -->
     <version.switchyard.runtime>2.1.0.Final</version.switchyard.runtime>
-    <jbtis.version>4.4.1.CR1</jbtis.version>
+    <jbtis.version>4.4.1.CR2</jbtis.version>
     <jbtis.classifier>base</jbtis.classifier> <!-- base-ea -->
     
     <!-- Tycho versions -->

--- a/targetplatform/switchyard-dev.target
+++ b/targetplatform/switchyard-dev.target
@@ -2,12 +2,12 @@
 <?pde version="3.8"?><target name="switchyard-dev" sequenceNumber="3">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.bpmn2.modeler.runtime.jboss.source.feature.group" version="1.3.1.Final-v20160831-1132-B55"/>
-<unit id="org.eclipse.bpmn2.feature.feature.group" version="1.3.0.Final-v20160119-1832"/>
-<unit id="org.eclipse.bpmn2.modeler.feature.group" version="1.3.1.Final-v20160831-1132-B55"/>
-<unit id="org.eclipse.bpmn2.modeler.runtime.jboss.feature.group" version="1.3.1.Final-v20160831-1132-B55"/>
-<unit id="org.eclipse.bpmn2.modeler.source.feature.group" version="1.3.1.Final-v20160831-1132-B55"/>
-<repository location="http://download.jboss.org/jbosstools/updates/requirements/bpmn2-modeler/1.3.1.Final_1.3.0.Final_neon/"/>
+<unit id="org.eclipse.bpmn2.modeler.runtime.jboss.source.feature.group" version="1.3.2.Final-v20161020-1541-B59"/>
+<unit id="org.eclipse.bpmn2.feature.feature.group" version="1.3.1.Final-v20160927-2047-B56"/>
+<unit id="org.eclipse.bpmn2.modeler.feature.group" version="1.3.2.Final-v20161020-1541-B59"/>
+<unit id="org.eclipse.bpmn2.modeler.runtime.jboss.feature.group" version="1.3.2.Final-v20161020-1541-B59"/>
+<unit id="org.eclipse.bpmn2.modeler.source.feature.group" version="1.3.2.Final-v20161020-1541-B59"/>
+<repository location="http://download.jboss.org/jbosstools/updates/requirements/bpmn2-modeler/1.3.2.Final_1.3.1.Final_neon/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
-- also adjusting org.eclipse.core.runtime version to be more up to date
- hasn't changed in forever
-- also updated the path to the latest BPMN2 modeler for neon