### PR TITLE
SWITCHYARD-2993 - updating to 2.4.0 in master

### DIFF
--- a/eclipse/features/org.switchyard.tools.bpel.feature/feature.xml
+++ b/eclipse/features/org.switchyard.tools.bpel.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.switchyard.tools.bpel.feature"
       label="%featureName"
-      version="2.3.0.qualifier"
+      version="2.4.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/eclipse/features/org.switchyard.tools.bpel.feature/pom.xml
+++ b/eclipse/features/org.switchyard.tools.bpel.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-features</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.bpel.feature</artifactId>

--- a/eclipse/features/org.switchyard.tools.bpmn2.feature/feature.xml
+++ b/eclipse/features/org.switchyard.tools.bpmn2.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.switchyard.tools.bpmn2.feature"
       label="%featureName"
-      version="2.3.0.qualifier"
+      version="2.4.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/eclipse/features/org.switchyard.tools.bpmn2.feature/pom.xml
+++ b/eclipse/features/org.switchyard.tools.bpmn2.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-features</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.bpmn2.feature</artifactId>

--- a/eclipse/features/org.switchyard.tools.feature/feature.xml
+++ b/eclipse/features/org.switchyard.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.switchyard.tools.feature"
       label="%featureName"
-      version="2.3.0.qualifier"
+      version="2.4.0.qualifier"
       provider-name="%featureProvider"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0"

--- a/eclipse/features/org.switchyard.tools.feature/pom.xml
+++ b/eclipse/features/org.switchyard.tools.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-features</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.feature</artifactId>

--- a/eclipse/features/pom.xml
+++ b/eclipse/features/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>switchyard-tools-eclipse-features</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.core/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools.core
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/eclipse/plugins/org.switchyard.tools.core/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
     <groupId>org.switchyard.tools</groupId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.core</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.cxf/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.cxf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools.cxf;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-Activator: org.switchyard.tools.cxf.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,

--- a/eclipse/plugins/org.switchyard.tools.cxf/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.cxf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.cxf</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.m2e/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.m2e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools.m2e;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.core.resources;bundle-version="3.4.2",

--- a/eclipse/plugins/org.switchyard.tools.m2e/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.m2e/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
     <groupId>org.switchyard.tools</groupId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.m2e</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.models.sca.core.edit/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.models.sca.core.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.switchyard.tools.models.sca.core.edit;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.soa.sca.core.model.CoreSCAEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/eclipse/plugins/org.switchyard.tools.models.sca.core.edit/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.models.sca.core.edit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/eclipse/plugins/org.switchyard.tools.models.sca.core/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.models.sca.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.switchyard.tools.models.sca.core;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/eclipse/plugins/org.switchyard.tools.models.sca.core/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.models.sca.core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/eclipse/plugins/org.switchyard.tools.models.sca.sca1_1.edit/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.models.sca.sca1_1.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.switchyard.tools.models.sca.sca1_1.edit;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.soa.sca.sca1_1.model.sca.provider.ScaEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/eclipse/plugins/org.switchyard.tools.models.sca.sca1_1.edit/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.models.sca.sca1_1.edit/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.switchyard.tools</groupId>
 		<artifactId>switchyard-tools-eclipse-plugins</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.4.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/eclipse/plugins/org.switchyard.tools.models.sca.sca1_1/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.models.sca.sca1_1/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.switchyard.tools.models.sca.sca1_1;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/eclipse/plugins/org.switchyard.tools.models.sca.sca1_1/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.models.sca.sca1_1/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/eclipse/plugins/org.switchyard.tools.models.switchyard1_0/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.models.switchyard1_0/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.switchyard.tools.models.switchyard1_0;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/eclipse/plugins/org.switchyard.tools.models.switchyard1_0/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.models.switchyard1_0/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.models.switchyard1_0</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.ui.bpel/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpel/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools.ui.bpel;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/eclipse/plugins/org.switchyard.tools.ui.bpel/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpel/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
     <groupId>org.switchyard.tools</groupId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.ui.bpel</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools.ui.bpmn2;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/eclipse/plugins/org.switchyard.tools.ui.bpmn2/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.bpmn2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
     <groupId>org.switchyard.tools</groupId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.ui.bpmn2</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.ui.debug/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools.ui.debug;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.switchyard.tools.ui.debug.Activator
 Bundle-Vendor: %Bundle-Vendor

--- a/eclipse/plugins/org.switchyard.tools.ui.debug/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.debug/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.ui.debug</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools.ui.editor;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-Activator: org.switchyard.tools.ui.editor.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.graphiti;bundle-version="[0.10.0,0.14.0)",

--- a/eclipse/plugins/org.switchyard.tools.ui.editor/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui.editor/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.ui.editor</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools.ui;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.switchyard.tools.ui.Activator
 Bundle-Vendor: %Bundle-Vendor

--- a/eclipse/plugins/org.switchyard.tools.ui/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.ui</artifactId>

--- a/eclipse/plugins/org.switchyard.tools.xsd/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools.xsd/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.switchyard.tools.xsd;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Require-Bundle: org.eclipse.wst.xml.core;bundle-version="1.0.0";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/eclipse/plugins/org.switchyard.tools.xsd/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools.xsd/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.xsd</artifactId>

--- a/eclipse/plugins/org.switchyard.tools/META-INF/MANIFEST.MF
+++ b/eclipse/plugins/org.switchyard.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.switchyard.tools
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/eclipse/plugins/org.switchyard.tools/pom.xml
+++ b/eclipse/plugins/org.switchyard.tools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse-plugins</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools</artifactId>

--- a/eclipse/plugins/pom.xml
+++ b/eclipse/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>switchyard-tools-eclipse-plugins</artifactId>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-parent</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>switchyard-tools-eclipse</artifactId>
@@ -14,7 +14,7 @@
     parent project's version, not being Eclipse specific, should continue to
     evolve along with the rest of the SwitchYard projects.
   -->
-  <version>2.3.0-SNAPSHOT</version>
+  <version>2.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SwitchYard: Eclipse Tools Parent</name>
   <description>Parent project for Eclipse based SwitchYard tooling.</description>

--- a/eclipse/site/pom.xml
+++ b/eclipse/site/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>switchyard-tools-eclipse-site</artifactId>

--- a/eclipse/tests/org.switchyard.tools.m2e.tests/META-INF/MANIFEST.MF
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for m2e Lifecycle Integration for SwitchYard
 Bundle-SymbolicName: org.switchyard.tools.m2e.tests;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.core.resources;bundle-version="3.4.2",

--- a/eclipse/tests/org.switchyard.tools.m2e.tests/pom.xml
+++ b/eclipse/tests/org.switchyard.tools.m2e.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>switchyard-tools-eclipse-tests</artifactId>
     <groupId>org.switchyard.tools</groupId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.m2e.tests</artifactId>

--- a/eclipse/tests/org.switchyard.tools.ui.tests/META-INF/MANIFEST.MF
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests SwitchYard Tools UI
 Bundle-SymbolicName: org.switchyard.tools.ui.tests;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0",
  org.eclipse.core.resources;bundle-version="3.4.2",

--- a/eclipse/tests/org.switchyard.tools.ui.tests/pom.xml
+++ b/eclipse/tests/org.switchyard.tools.ui.tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>switchyard-tools-eclipse-tests</artifactId>
     <groupId>org.switchyard.tools</groupId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>org.switchyard.tools.ui.tests</artifactId>

--- a/eclipse/tests/pom.xml
+++ b/eclipse/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.switchyard.tools</groupId>
     <artifactId>switchyard-tools-eclipse</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>switchyard-tools-eclipse-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
     
     <!-- Fuse version -->
-    <fuse-tooling-url>http://download.jboss.org/jbosstools/neon/staging/builds/integration-stack/fuse-tooling/9.1.0.CI/</fuse-tooling-url>
+    <fuse-tooling-url>http://download.jboss.org/jbosstools/neon/staging/builds/integration-stack/fuse-tooling/9.2.0.CI/</fuse-tooling-url>
     
     <illegaltransitivereportonly>true</illegaltransitivereportonly>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -52,5 +52,5 @@
     </repository>
   </repositories>
   
-  <version>2.3.0-SNAPSHOT</version>
+  <version>2.4.0-SNAPSHOT</version>
 </project>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -7,7 +7,7 @@
    <parent>
       <groupId>org.switchyard.tools</groupId>
       <artifactId>switchyard-tools-parent</artifactId>
-      <version>2.2.0-SNAPSHOT</version>
+      <version>2.4.0-SNAPSHOT</version>
       <relativePath>..</relativePath>
    </parent>
 


### PR DESCRIPTION
Once we update the Fuse master to whatever the next version is and the next Fuse tooling CI build is ready, we'll update this location as well:

https://github.com/jboss-switchyard/tools/blob/master/pom.xml#L27

So we'll hold off on merging this, just wanted to get the ball rolling.