### PR TITLE
JBTIS-1117 - updating to a more permanent, temporary fuse URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
     
     <!-- Fuse version -->
-    <fuse-tooling-url>http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-fuse_master/2017-05-31_15-20-44-B7-save/all/repo/</fuse-tooling-url>
+    <fuse-tooling-url>http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-fuse_master/</fuse-tooling-url>
     
     <illegaltransitivereportonly>true</illegaltransitivereportonly>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Created per @pleacu 's request:

"Andrej noticed that my saved URL for the fuse tooling bits got bot-cleaned again.  Since SwitchYard has temporarily added the Fuse Tooling URL into it's own domain I'll remove the fuse tooling bits completely from the jbtis TP.  So - Fitz - please update your URL to ref  http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-fuse_master/  and respin your oxygen bits.  This is temporary until Fuse Tooling ends up in JBT core proper"