### PR TITLE
JBTIS-1078a - remove direct fuse tooling reference in favor of JBTIS TP

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -38,34 +38,6 @@
         <enabled>true</enabled>
       </releases>
     </repository>
-     <repository>
-        <id>fuseide</id>
-        <name>JBoss Fuse IS Tooling</name>
-        <url>${fuse-tooling-url}</url>
-        <layout>p2</layout>
-     </repository>
-     <repository>
-      <id>fusesource.ea.repo</id>
-      <name>JBoss Fuse Early Access Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/groups/ea</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
-    <repository>
-      <id>fusesource.release.repo</id>
-      <name>JBoss Fuse Release Repository</name>
-      <url>https://repo.fusesource.com/nexus/content/repositories/releases</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
     <repository>
       <id>jboss.public.repo</id>
       <name>JBoss Public Repository</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,6 @@
     <tychoVersion>0.26.0</tychoVersion>
     <tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
     
-    <!-- Fuse version -->
-    <fuse-tooling-url>http://download.jboss.org/jbosstools/oxygen/staging/updates/integration-stack/proto/2017-06-02_13-53-35-B8/all/repo/</fuse-tooling-url>
-    
     <illegaltransitivereportonly>true</illegaltransitivereportonly>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Hey @bfitzpat - this removed the direct reference to fuse tooling in the POM - you'll get it from the JBTIS TP now.
